### PR TITLE
Ingestfeil

### DIFF
--- a/ingestors/arena-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena/domain/ArenaData.kt
+++ b/ingestors/arena-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena/domain/ArenaData.kt
@@ -22,7 +22,11 @@ internal data class ArenaData(
 		ingestedTimestamp = LocalDateTime.now()
 	)
 
-	fun markAsFailed() = this.copy(ingestStatus = IngestStatus.FAILED)
+	fun markAsFailed() = this.copy(
+		ingestStatus = IngestStatus.FAILED,
+		ingestAttempts = ingestAttempts + 1,
+		lastRetry = LocalDateTime.now()
+	)
 
 	fun retry() = this.copy(
 		ingestStatus = IngestStatus.RETRY,

--- a/ingestors/arena-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena/processors/GjennomforingProcessor.kt
+++ b/ingestors/arena-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena/processors/GjennomforingProcessor.kt
@@ -42,8 +42,8 @@ internal open class GjennomforingProcessor(
 			return
 		}
 
-		if (newFields.ARBGIV_ID_ARRANGOR == null) {
-			log.info("Hopper over upsert av tiltakgjennomforing som mangler ARBGIV_ID_ARRANGOR. arenaTiltakgjennomforingId=${newFields.TILTAKGJENNOMFORING_ID}")
+		if (ugyldigGjennomforing(newFields)) {
+			log.info("Hopper over upsert av tiltakgjennomforing som mangler data. arenaTiltakgjennomforingId=${newFields.TILTAKGJENNOMFORING_ID}")
 			repository.upsert(data.markAsIgnored())
 			return
 		}
@@ -59,8 +59,7 @@ internal open class GjennomforingProcessor(
 			arenaId = newFields.TILTAKGJENNOMFORING_ID.toInt(),
 			tiltakId = tiltak.id,
 			arrangorId = arrangor.id,
-			navn = newFields.LOKALTNAVN
-				?: throw DataIntegrityViolationException("Forventet at LOKALTNAVN ikke er null"),
+			navn = newFields.LOKALTNAVN.toString(),
 			status = null,
 			oppstartDato = newFields.DATO_FRA?.asLocalDate(),
 			sluttDato = newFields.DATO_TIL?.asLocalDate(),
@@ -76,5 +75,8 @@ internal open class GjennomforingProcessor(
 		log.error("Delete is not implemented for TiltaksgjennomforingProcessor")
 		repository.upsert(data.markAsFailed())
 	}
+
+	private fun ugyldigGjennomforing(data: ArenaTiltaksgjennomforing) =
+		data.ARBGIV_ID_ARRANGOR == null || data.LOKALTNAVN == null
 
 }

--- a/ingestors/arena-ingestor/src/test/kotlin/no/nav/amt/tiltak/ingestors/arena/repository/ArenaDataRepositoryTest.kt
+++ b/ingestors/arena-ingestor/src/test/kotlin/no/nav/amt/tiltak/ingestors/arena/repository/ArenaDataRepositoryTest.kt
@@ -119,14 +119,17 @@ internal class ArenaDataRepositoryTest {
 	fun `markAsFailed() should mark data as failed`() {
 
 		val uningestedArenaData = arenaDataRepository.getById(4)
-
 		assertEquals(IngestStatus.RETRY, uningestedArenaData.ingestStatus)
 
+		val beforeLastRetry = LocalDateTime.now()
 		arenaDataRepository.upsert(uningestedArenaData.markAsFailed())
 
 		val failedArenaData = arenaDataRepository.getById(4)
 
 		assertEquals(IngestStatus.FAILED, failedArenaData.ingestStatus)
+		assertEquals(uningestedArenaData.ingestAttempts + 1, failedArenaData.ingestAttempts)
+		assertTrue(failedArenaData.lastRetry!!.isAfter(beforeLastRetry))
+
 	}
 
 	@Test


### PR DESCRIPTION
- Øker ingest attempts også når ingest har feilet mer enn 10 ganger, denne kan potensielt bli kjørt mange ganger for permanente feil. 
- Ignorerer tiltak som ikke har navn, disse spammer loggene nå fordi ingest vil forsøke et uendelig antall ganger å ingeste til ting slutter å feile

https://trello.com/c/DCfa5oFN/172-ingestor-vil-konstant-fors%C3%B8ke-%C3%A5-ingeste-ting-som-har-feilet-10-ganger