### PR TITLE
Fjerner loop som fortsetter uendelig ved feilende data

### DIFF
--- a/ingestors/arena-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena/ArenaDataProcessor.kt
+++ b/ingestors/arena-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena/ArenaDataProcessor.kt
@@ -38,14 +38,10 @@ internal open class ArenaDataProcessor(
 	}
 
 	private fun processMessages(getter: () -> List<ArenaData>) {
-		var messages: List<ArenaData>
-
-		do {
-			val start = Instant.now()
-			messages = getter()
-			messages.forEach { processMessage(it) }
-			log(start, messages)
-		} while (messages.isNotEmpty())
+		val messages = getter()
+		val start = Instant.now()
+		messages.forEach { processMessage(it) }
+		log(start, messages)
 	}
 
 	private fun log(start: Instant, messages: List<ArenaData>) {

--- a/ingestors/arena-ingestor/src/test/kotlin/no/nav/amt/tiltak/ingestors/arena/processors/ArenaDataProcessorIntegrationTest.kt
+++ b/ingestors/arena-ingestor/src/test/kotlin/no/nav/amt/tiltak/ingestors/arena/processors/ArenaDataProcessorIntegrationTest.kt
@@ -1,9 +1,12 @@
 package no.nav.amt.tiltak.ingestors.arena.processors
 
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import no.nav.amt.tiltak.core.domain.tiltak.Tiltak
 import no.nav.amt.tiltak.core.port.TiltakService
 import no.nav.amt.tiltak.ingestors.arena.ArenaDataProcessor
 import no.nav.amt.tiltak.ingestors.arena.domain.ArenaData
+import no.nav.amt.tiltak.ingestors.arena.domain.IngestStatus
 import no.nav.amt.tiltak.ingestors.arena.domain.OperationType
 import no.nav.amt.tiltak.ingestors.arena.repository.ArenaDataRepository
 import no.nav.amt.tiltak.test.database.SingletonPostgresContainer
@@ -15,6 +18,7 @@ import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.time.LocalDateTime
+import java.util.*
 
 class ArenaDataProcessorIntegrationTest {
 	private val dataSource = SingletonPostgresContainer.getDataSource()
@@ -29,6 +33,9 @@ class ArenaDataProcessorIntegrationTest {
 
 	private lateinit var arenaDataProcessor: ArenaDataProcessor
 	private var tiltakTabellnavn = "SIAMO.TILTAK"
+
+	val tiltak = Tiltak(UUID.randomUUID(), "INDOPPFAG", "Oppfølging")
+	val insertOppfTiltak = { tiltakService.upsertTiltak(tiltak.kode, tiltak.navn, tiltak.kode) }
 
 	@BeforeEach
 	fun beforeAll() {
@@ -45,44 +52,6 @@ class ArenaDataProcessorIntegrationTest {
 	@Test
 	fun `processUningestedMessages() - Skal ingeste oppfølgingstiltak`() {
 
-		val after = """
-			{
-			  "TILTAKSNAVN": "Oppfølging",
-			  "TILTAKSGRUPPEKODE": "OPPFOLG",
-			  "REG_DATO": "2009-01-01 07:26:30",
-			  "REG_USER": "SIAMO",
-			  "MOD_DATO": "2021-04-14 09:44:13",
-			  "MOD_USER": "SIAMO",
-			  "TILTAKSKODE": "INDOPPFAG",
-			  "DATO_FRA": "2009-01-01 00:00:00",
-			  "DATO_TIL": "2099-01-01 00:00:00",
-			  "AVSNITT_ID_GENERELT": null,
-			  "STATUS_BASISYTELSE": "J",
-			  "ADMINISTRASJONKODE": "INST",
-			  "STATUS_KOPI_TILSAGN": "N",
-			  "ARKIVNOKKEL": "829",
-			  "STATUS_ANSKAFFELSE": "J",
-			  "MAKS_ANT_PLASSER": null,
-			  "MAKS_ANT_SOKERE": null,
-			  "STATUS_FAST_ANT_PLASSER": "N",
-			  "STATUS_SJEKK_ANT_DELTAKERE": "N",
-			  "STATUS_KALKULATOR": "N",
-			  "RAMMEAVTALE": "KAN",
-			  "OPPLAERINGSGRUPPE": null,
-			  "HANDLINGSPLAN": "SOK",
-			  "STATUS_SLUTTDATO": "J",
-			  "MAKS_PERIODE": null,
-			  "STATUS_MELDEPLIKT": "N",
-			  "STATUS_VEDTAK": "J",
-			  "STATUS_IA_AVTALE": "N",
-			  "STATUS_TILLEGGSSTONADER": "J",
-			  "STATUS_UTDANNING": "N",
-			  "AUTOMATISK_TILSAGNSBREV": "N",
-			  "STATUS_BEGRUNNELSE_INNSOKT": "N",
-			  "STATUS_HENVISNING_BREV": "J",
-			  "STATUS_KOPIBREV": "N"
-			}""".trimIndent()
-
 		val arenaData = ArenaData(
 			id = 1,
 			tableName = tiltakTabellnavn,
@@ -97,14 +66,62 @@ class ArenaDataProcessorIntegrationTest {
 		arenaDataProcessor.processUningestedMessages()
 
 		arenaDataRepository.getUningestedData(tiltakTabellnavn) shouldHaveSize 0
-		verify(tiltakService, times(1)).upsertTiltak("INDOPPFAG", "Oppfølging", "INDOPPFAG")
+		verify(tiltakService, times(1)).upsertTiltak(tiltak.kode, tiltak.navn, tiltak.kode)
 
 	}
 
 	@Test
 	fun `processUningestedMessages() - Skal forsøke å ingeste 11 ganger`() {
 
-		val after = """
+		val arenaData = ArenaData(
+			id = 1,
+			tableName = tiltakTabellnavn,
+			operationType = OperationType.INSERT,
+			operationPosition = 1L,
+			operationTimestamp = LocalDateTime.now(),
+			after = after
+		)
+		arenaDataRepository.upsert(arenaData)
+		arenaDataRepository.getUningestedData(tiltakTabellnavn) shouldHaveSize 1
+
+		`when`(insertOppfTiltak())
+			.thenThrow(DataIntegrityViolationException::class.java)
+
+		arenaDataProcessor.processUningestedMessages()
+		repeat(10) { arenaDataProcessor.processUningestedMessages() }
+
+		val failedData = arenaDataRepository.getFailedData(tiltakTabellnavn)
+
+		failedData shouldHaveSize 1
+		failedData[0].ingestStatus shouldBe IngestStatus.FAILED
+		failedData[0].ingestAttempts shouldBe 11
+	}
+
+	@Test
+	fun `processFailedMessages() - tiltak har feilet tidligere - skal ingestes`() {
+		val arenaData = ArenaData(
+			id = 1,
+			tableName = tiltakTabellnavn,
+			operationType = OperationType.INSERT,
+			operationPosition = 1L,
+			operationTimestamp = LocalDateTime.now(),
+			after = after,
+			ingestAttempts = 10,
+			ingestStatus = IngestStatus.FAILED
+		)
+		arenaDataRepository.upsert(arenaData)
+
+		`when`(insertOppfTiltak())
+			.thenReturn(tiltak)
+
+		arenaDataProcessor.processFailedMessages()
+		val failedData = arenaDataRepository.getFailedData(tiltakTabellnavn)
+
+		failedData shouldHaveSize 0
+
+	}
+
+	val after = """
 			{
 			  "TILTAKSNAVN": "Oppfølging",
 			  "TILTAKSGRUPPEKODE": "OPPFOLG",
@@ -141,37 +158,5 @@ class ArenaDataProcessorIntegrationTest {
 			  "STATUS_HENVISNING_BREV": "J",
 			  "STATUS_KOPIBREV": "N"
 			}""".trimIndent()
-
-		val arenaData = ArenaData(
-			id = 1,
-			tableName = tiltakTabellnavn,
-			operationType = OperationType.INSERT,
-			operationPosition = 1L,
-			operationTimestamp = LocalDateTime.now(),
-			after = after
-		)
-		arenaDataRepository.upsert(arenaData)
-		arenaDataRepository.getUningestedData(tiltakTabellnavn) shouldHaveSize 1
-		`when`(tiltakService.upsertTiltak("INDOPPFAG", "Oppfølging", "INDOPPFAG"))
-			.thenThrow(DataIntegrityViolationException::class.java)
-
-		arenaDataProcessor.processUningestedMessages()
-
-		arenaDataRepository.getUningestedData(tiltakTabellnavn) shouldHaveSize 0
-		arenaDataRepository.getFailedData(tiltakTabellnavn) shouldHaveSize 1
-
-		verify(tiltakService, times(11)).upsertTiltak("INDOPPFAG", "Oppfølging", "INDOPPFAG")
-
-	}
-
-	@Test
-	fun `Ingest skal inserte tiltakdeltaker gitt at alt skal være ok`() {
-		//Venter med implementasjon til ingest er flyttet
-	}
-
-	@Test
-	fun `Ingest skal feile gitt at eksterne avhengigheter feiler`() {
-		//Venter med implementasjon til ingest er flyttet
-	}
 
 }


### PR DESCRIPTION
Tror dette er løsningen fordi cron jobben vil sørge for at det forsøkes å inserte på nytt når ting har feilet
https://trello.com/c/DCfa5oFN/172-ingestor-vil-konstant-fors%C3%B8ke-%C3%A5-ingeste-ting-som-har-feilet-10-ganger