### PR TITLE
Diverse feilrettinger status

### DIFF
--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Deltaker.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Deltaker.kt
@@ -19,11 +19,11 @@ data class Deltaker(
 		VENTER_PA_OPPSTART, DELTAR, HAR_SLUTTET, IKKE_AKTUELL
 	}
 
-	fun updateStatus(
+	fun update(
 		newStatus: Status,
 		newDeltakerStartDato: LocalDate?,
 		newDeltakerSluttDato: LocalDate?,
-		newStatusEndretDato: LocalDate = LocalDate.now()
+		newStatusEndretDato: LocalDateTime = LocalDateTime.now()
 	): Deltaker {
 
 		return if (statuser.current.status != newStatus

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/DeltakerStatuser.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/DeltakerStatuser.kt
@@ -1,6 +1,5 @@
 package no.nav.amt.tiltak.core.domain.tiltak
-
-import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.*
 
 data class DeltakerStatuser(
@@ -11,7 +10,7 @@ data class DeltakerStatuser(
 	}
 
 	companion object {
-		fun settAktivStatus(status: Deltaker.Status, endretDato: LocalDate = LocalDate.now()) =
+		fun settAktivStatus(status: Deltaker.Status, endretDato: LocalDateTime = LocalDateTime.now()) =
 			DeltakerStatuser(listOf(DeltakerStatus.settAktiv(
 				status = status,
 				endretDato = endretDato
@@ -20,7 +19,7 @@ data class DeltakerStatuser(
 
 	val current: DeltakerStatus = statuser.find { it.aktiv }!!
 
-	fun medNy(status: Deltaker.Status, endretDato: LocalDate) = DeltakerStatuser(
+	fun medNy(status: Deltaker.Status, endretDato: LocalDateTime) = DeltakerStatuser(
 		statuser.map { it.deaktiver() } + DeltakerStatus.settAktiv(status = status, endretDato = endretDato)
 	)
 }
@@ -28,15 +27,15 @@ data class DeltakerStatuser(
 data class DeltakerStatus(
 	val id: UUID = UUID.randomUUID(),
 	val status: Deltaker.Status,
-	val endretDato: LocalDate,
+	val endretDato: LocalDateTime,
 	val aktiv: Boolean = false
 ) {
 
 	companion object {
-		fun settAktiv(status: Deltaker.Status, endretDato: LocalDate = LocalDate.now()) =
+		fun settAktiv(status: Deltaker.Status, endretDato: LocalDateTime = LocalDateTime.now()) =
 			DeltakerStatus(status = status, endretDato = endretDato, aktiv = true)
 
-		fun nyInaktiv(status: Deltaker.Status, endretDato: LocalDate = LocalDate.now()) =
+		fun nyInaktiv(status: Deltaker.Status, endretDato: LocalDateTime = LocalDateTime.now()) =
 			DeltakerStatus(status = status, endretDato = endretDato, aktiv = false)
 	}
 

--- a/core/src/test/kotlin/no/nav/amt/tiltak/core/domain/tiltak/DeltakerStatuserTest.kt
+++ b/core/src/test/kotlin/no/nav/amt/tiltak/core/domain/tiltak/DeltakerStatuserTest.kt
@@ -4,11 +4,11 @@ import no.nav.amt.tiltak.core.domain.tiltak.Deltaker.Status.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 class DeltakerStatuserTest {
 
-	val now: LocalDate = LocalDate.now()
+	val now: LocalDateTime = LocalDateTime.now()
 
 	@Test
 	fun `current - inneholder gjeldende status`() {

--- a/core/src/test/kotlin/no/nav/amt/tiltak/core/domain/tiltak/DeltakerTest.kt
+++ b/core/src/test/kotlin/no/nav/amt/tiltak/core/domain/tiltak/DeltakerTest.kt
@@ -19,11 +19,11 @@ class DeltakerTest {
 			sluttDato = tomorrow,
 			statuser = DeltakerStatuser(listOf(DeltakerStatus.settAktiv(
 					status = Deltaker.Status.VENTER_PA_OPPSTART,
-					endretDato = LocalDate.now().minusWeeks(1)
+					endretDato = LocalDateTime.now().minusWeeks(1)
 			))),
 			registrertDato = LocalDateTime.now().minusWeeks(1),
 		)
-		val updatedDeltaker = deltaker.updateStatus(Deltaker.Status.DELTAR, yesterday, tomorrow, LocalDate.now())
+		val updatedDeltaker = deltaker.update(Deltaker.Status.DELTAR, yesterday, tomorrow, LocalDateTime.now())
 
 		assertNotEquals(updatedDeltaker, deltaker)
 		assertEquals(updatedDeltaker.status, Deltaker.Status.DELTAR)
@@ -37,12 +37,12 @@ class DeltakerTest {
 			sluttDato = LocalDate.now().plusWeeks(1),
 			statuser = DeltakerStatuser(listOf(DeltakerStatus(
 				status = Deltaker.Status.VENTER_PA_OPPSTART,
-				endretDato = LocalDate.now().minusWeeks(1),
+				endretDato = LocalDateTime.now().minusWeeks(1),
 				aktiv = true
 			))),
 			registrertDato = LocalDateTime.now().minusWeeks(1),
 		)
-		val updatedDeltaker = deltaker.updateStatus(Deltaker.Status.VENTER_PA_OPPSTART, tomorrow,  LocalDate.now().plusWeeks(1), LocalDate.now())
+		val updatedDeltaker = deltaker.update(Deltaker.Status.VENTER_PA_OPPSTART, tomorrow,  LocalDate.now().plusWeeks(1), LocalDateTime.now())
 
 		assertNotEquals(updatedDeltaker, deltaker)
 		assertEquals(updatedDeltaker.startDato, tomorrow)
@@ -55,11 +55,11 @@ class DeltakerTest {
 			sluttDato = yesterday,
 			statuser = DeltakerStatuser(listOf(DeltakerStatus.settAktiv(
 				status = Deltaker.Status.DELTAR,
-				endretDato = LocalDate.now().minusWeeks(1),
+				endretDato = LocalDateTime.now().minusWeeks(1),
 			))),
 			registrertDato = LocalDateTime.now().minusWeeks(1),
 		)
-		val updatedDeltaker = deltaker.updateStatus(Deltaker.Status.DELTAR, LocalDate.now().minusWeeks(1),  tomorrow, LocalDate.now())
+		val updatedDeltaker = deltaker.update(Deltaker.Status.DELTAR, LocalDate.now().minusWeeks(1),  tomorrow, LocalDateTime.now())
 
 		assertNotEquals(updatedDeltaker, deltaker)
 		assertEquals(updatedDeltaker.sluttDato, tomorrow)
@@ -72,16 +72,16 @@ class DeltakerTest {
 			sluttDato = yesterday,
 			statuser = DeltakerStatuser(listOf(DeltakerStatus.settAktiv(
 				status = Deltaker.Status.DELTAR,
-				endretDato = LocalDate.now().minusWeeks(1),
+				endretDato = LocalDateTime.now().minusWeeks(1),
 			))),
 			registrertDato = LocalDateTime.now().minusWeeks(1),
 		)
 
-		val updatedDeltaker = deltaker.updateStatus(
+		val updatedDeltaker = deltaker.update(
 			Deltaker.Status.DELTAR,
 			LocalDate.now().minusWeeks(1),
 			yesterday,
-			LocalDate.now()
+			LocalDateTime.now()
 		)
 
 		assertEquals(updatedDeltaker, deltaker)

--- a/db-migrations/src/main/resources/db/migration/V4__deltaker_table_status_endret.sql
+++ b/db-migrations/src/main/resources/db/migration/V4__deltaker_table_status_endret.sql
@@ -4,9 +4,10 @@ CREATE TABLE deltaker_status
 (
     id          uuid PRIMARY KEY NOT NULL,
     deltaker_id uuid references deltaker (id),
-    endret_dato date,
+    endret_dato timestamp with time zone,
     status      varchar          NOT NULL,
     active      boolean,
+    created_at timestamp with time zone not null default current_timestamp,
 
     UNIQUE (deltaker_id, endret_dato, status)
 );

--- a/ingestors/arena-acl-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena_acl_ingestor/dto/DeltakerPayload.kt
+++ b/ingestors/arena-acl-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena_acl_ingestor/dto/DeltakerPayload.kt
@@ -14,7 +14,7 @@ data class DeltakerPayload(
 	val dagerPerUke: Int?,
 	val prosentDeltid: Float?,
 	val registrertDato: LocalDateTime,
-	val statusEndretDato: LocalDate
+	val statusEndretDato: LocalDateTime
 ) {
 	enum class Status {
 		VENTER_PA_OPPSTART, DELTAR, HAR_SLUTTET, IKKE_AKTUELL

--- a/ingestors/arena-acl-ingestor/src/test/kotlin/no/nav/amt/tiltak/ingestors/arena_acl_ingestor/processor/DeltakerProcessorTest.kt
+++ b/ingestors/arena-acl-ingestor/src/test/kotlin/no/nav/amt/tiltak/ingestors/arena_acl_ingestor/processor/DeltakerProcessorTest.kt
@@ -8,7 +8,6 @@ import no.nav.amt.tiltak.core.port.*
 import no.nav.amt.tiltak.ingestors.arena_acl_ingestor.dto.DeltakerPayload
 import no.nav.amt.tiltak.ingestors.arena_acl_ingestor.dto.MessageWrapper
 import no.nav.amt.tiltak.ingestors.arena_acl_ingestor.dto.Operation
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -46,7 +45,7 @@ class DeltakerProcessorTest : StringSpec({
 				dagerPerUke = null,
 				prosentDeltid = null,
 				registrertDato = LocalDateTime.now(),
-				statusEndretDato = LocalDate.now()
+				statusEndretDato = LocalDateTime.now()
 			)
 		))
 

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/dbo/DeltakerStatusDbo.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/dbo/DeltakerStatusDbo.kt
@@ -3,14 +3,14 @@ package no.nav.amt.tiltak.deltaker.dbo
 import no.nav.amt.tiltak.core.domain.tiltak.Deltaker
 import no.nav.amt.tiltak.core.domain.tiltak.DeltakerStatus
 import no.nav.amt.tiltak.core.domain.tiltak.DeltakerStatuser
-import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.*
 
 data class DeltakerStatusDbo(
 	val id: UUID = UUID.randomUUID(),
 	val deltakerId: UUID,
 	val status: Deltaker.Status,
-	val endretDato: LocalDate,
+	val endretDato: LocalDateTime,
 	val aktiv: Boolean
 ) {
 

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/repositories/DeltakerStatusRepository.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/repositories/DeltakerStatusRepository.kt
@@ -19,7 +19,7 @@ open class DeltakerStatusRepository(
 		DeltakerStatusDbo(
 			id = rs.getUUID("id"),
 			deltakerId = rs.getUUID("deltaker_id"),
-			endretDato = rs.getTimestamp("endret_dato").toLocalDateTime().toLocalDate(),
+			endretDato = rs.getTimestamp("endret_dato").toLocalDateTime(),
 			status = Deltaker.Status.valueOf(rs.getString("status")),
 			aktiv = rs.getBoolean("active"),
 		)

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
@@ -24,7 +24,7 @@ open class DeltakerServiceImpl(
 			createDeltaker(fodselsnummer, gjennomforingId, deltaker)
 		} else {
 			val lagretDeltaker = lagretDeltakerDbo.toDeltaker(deltakerStatusRepository::getStatuserForDeltaker)
-			val oppdatertDeltaker = lagretDeltaker.updateStatus(deltaker.status, deltaker.startDato, deltaker.sluttDato)
+			val oppdatertDeltaker = lagretDeltaker.update(deltaker.status, deltaker.startDato, deltaker.sluttDato, deltaker.statuser.current.endretDato)
 
 			if (lagretDeltaker != oppdatertDeltaker) {
 				update(oppdatertDeltaker)

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/repositories/GjennomforingRepository.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/repositories/GjennomforingRepository.kt
@@ -73,7 +73,7 @@ open class GjennomforingRepository(private val template: NamedParameterJdbcTempl
 		template.update(sql, parameters)
 
 		return get(id)
-			?: throw NoSuchElementException("Tiltak med id $id finnes ikke")
+			?: throw NoSuchElementException("Gjennomføring med id $id finnes ikke")
 	}
 
 	fun update(gjennomforing: GjennomforingDbo): GjennomforingDbo {

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/DeltakerServiceImplTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/DeltakerServiceImplTest.kt
@@ -1,0 +1,157 @@
+package no.nav.amt.tiltak.deltaker
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.mockk
+import no.nav.amt.tiltak.core.domain.tiltak.Deltaker
+import no.nav.amt.tiltak.core.domain.tiltak.DeltakerStatuser
+import no.nav.amt.tiltak.core.port.BrukerService
+import no.nav.amt.tiltak.deltaker.repositories.BrukerRepository
+import no.nav.amt.tiltak.deltaker.repositories.DeltakerRepository
+import no.nav.amt.tiltak.deltaker.repositories.DeltakerStatusRepository
+import no.nav.amt.tiltak.deltaker.service.DeltakerServiceImpl
+import no.nav.amt.tiltak.test.database.DatabaseTestUtils
+import no.nav.amt.tiltak.test.database.SingletonPostgresContainer
+import no.nav.amt.tiltak.tiltak.services.BrukerServiceImpl
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import java.time.LocalDateTime
+import java.util.*
+
+class DeltakerServiceImplTest {
+	lateinit var deltakerRepository: DeltakerRepository
+	lateinit var deltakerStatusRepository: DeltakerStatusRepository
+	lateinit var deltakerServiceImpl: DeltakerServiceImpl
+	lateinit var brukerRepository: BrukerRepository
+	lateinit var brukerService: BrukerService
+
+	val datasource = SingletonPostgresContainer.getDataSource()
+	val jdbcTemplate = NamedParameterJdbcTemplate(datasource)
+	val fnr = "12345678910"
+	val deltakerId = UUID.randomUUID()
+	val gjennomforingId = UUID.fromString("b3420940-5479-48c8-b2fa-3751c7a33aa2")
+
+	@BeforeEach
+	fun beforeEach() {
+		brukerRepository = BrukerRepository(jdbcTemplate)
+
+		brukerService = BrukerServiceImpl(brukerRepository, mockk(), mockk(), mockk(), mockk())
+		deltakerRepository = DeltakerRepository(jdbcTemplate)
+		deltakerStatusRepository = DeltakerStatusRepository(jdbcTemplate)
+		deltakerServiceImpl = DeltakerServiceImpl(deltakerRepository, deltakerStatusRepository, brukerService)
+
+		DatabaseTestUtils.runScriptFile(datasource, "/deltaker-repository_test-data.sql")
+	}
+
+	@AfterEach
+	fun afterEach() {
+		DatabaseTestUtils.cleanDatabase(datasource)
+	}
+
+	@Test
+	fun `upsertDeltaker - inserter ny deltaker`() {
+		deltakerServiceImpl.upsertDeltaker(fnr, gjennomforingId = gjennomforingId, deltaker)
+
+		val nyDeltaker = deltakerRepository.get(fnr, gjennomforingId)
+
+		nyDeltaker shouldNotBe null
+
+		val statuser = deltakerStatusRepository.getStatuserForDeltaker(deltakerId)
+
+		statuser shouldHaveSize 1
+		statuser.first().status shouldBe Deltaker.Status.DELTAR
+		statuser.first().aktiv shouldBe true
+	}
+
+	@Test
+	fun `upsertDeltaker - deltaker får ny status - oppdaterer status på deltaker`() {
+
+		deltakerServiceImpl.upsertDeltaker(fnr, gjennomforingId = gjennomforingId, deltaker)
+
+		var nyDeltaker = deltakerRepository.get(fnr, gjennomforingId)
+		var statuser = deltakerStatusRepository.getStatuserForDeltaker(deltakerId)
+
+		nyDeltaker shouldNotBe null
+		statuser shouldHaveSize 1
+
+		val endretStatus = status.medNy(Deltaker.Status.HAR_SLUTTET, LocalDateTime.now())
+		val endretDeltaker = deltaker.copy(statuser = endretStatus)
+
+		deltakerServiceImpl.upsertDeltaker(fnr, gjennomforingId, endretDeltaker)
+
+		nyDeltaker = deltakerRepository.get(fnr, gjennomforingId)
+		statuser = deltakerStatusRepository.getStatuserForDeltaker(deltakerId)
+		val aktivStatus = statuser.first{ it.aktiv }
+
+		nyDeltaker shouldNotBe null
+		statuser shouldHaveSize 2
+		aktivStatus.status shouldBe Deltaker.Status.HAR_SLUTTET
+
+	}
+
+
+	@Test
+	fun `upsertDeltaker - deltaker får samme status igjen - oppdaterer ikke status`() {
+
+		deltakerServiceImpl.upsertDeltaker(fnr, gjennomforingId = gjennomforingId, deltaker)
+		var nyDeltaker = deltakerRepository.get(fnr, gjennomforingId)
+		var statuser = deltakerStatusRepository.getStatuserForDeltaker(deltakerId)
+
+		nyDeltaker shouldNotBe null
+		statuser shouldHaveSize 1
+
+		deltakerServiceImpl.upsertDeltaker(fnr, gjennomforingId, deltaker)
+
+		nyDeltaker = deltakerRepository.get(fnr, gjennomforingId)
+		statuser = deltakerStatusRepository.getStatuserForDeltaker(deltakerId)
+		val aktivStatus = statuser.first{ it.aktiv }
+
+		nyDeltaker shouldNotBe null
+		statuser shouldHaveSize 1
+		aktivStatus.status shouldBe Deltaker.Status.DELTAR
+
+	}
+
+	@Test
+	fun `upsertDeltaker - deltaker får samme status på nytt etter opphold - oppdaterer status`() {
+
+		deltakerServiceImpl.upsertDeltaker(fnr, gjennomforingId = gjennomforingId, deltaker)
+
+		var nyDeltaker = deltakerRepository.get(fnr, gjennomforingId)
+		var statuser = deltakerStatusRepository.getStatuserForDeltaker(deltakerId)
+
+		nyDeltaker shouldNotBe null
+		statuser shouldHaveSize 1
+
+		val endretDeltaker = deltaker.copy(statuser = DeltakerStatuser.settAktivStatus(Deltaker.Status.HAR_SLUTTET))
+
+		deltakerServiceImpl.upsertDeltaker(fnr, gjennomforingId, endretDeltaker)
+
+		nyDeltaker = deltakerRepository.get(fnr, gjennomforingId)
+		statuser = deltakerStatusRepository.getStatuserForDeltaker(deltakerId)
+		val aktivStatus = statuser.first{ it.aktiv }
+
+		nyDeltaker shouldNotBe null
+		statuser shouldHaveSize 2
+		aktivStatus.status shouldBe Deltaker.Status.HAR_SLUTTET
+
+		deltakerServiceImpl.upsertDeltaker(fnr, gjennomforingId, deltaker.copy(statuser = DeltakerStatuser.settAktivStatus(Deltaker.Status.DELTAR)))
+
+	}
+
+	val status = DeltakerStatuser.settAktivStatus(Deltaker.Status.DELTAR)
+
+	val deltaker = Deltaker(
+		id =  deltakerId,
+		bruker = null,
+		startDato = null,
+		sluttDato = null,
+		statuser =  status,
+		registrertDato =  LocalDateTime.now(),
+		dagerPerUke = null,
+		prosentStilling = null
+	)
+}

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/repositories/DeltakerRepositoryTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/repositories/DeltakerRepositoryTest.kt
@@ -29,7 +29,7 @@ internal class DeltakerRepositoryTest : FunSpec({
 		listOf(DeltakerStatusDbo(
 			deltakerId = id,
 			status = Deltaker.Status.DELTAR,
-			endretDato = LocalDate.now(),
+			endretDato = LocalDateTime.now(),
 			aktiv = true)
 		)
 
@@ -99,7 +99,7 @@ internal class DeltakerRepositoryTest : FunSpec({
 		val updatedSluttDato = LocalDate.now().plusDays(14)
 		val updatedStatus = Deltaker.Status.DELTAR
 
-		val updatedDeltaker = dbo.toDeltaker(statusConverterMock).updateStatus(updatedStatus, updatedStartDato, updatedSluttDato)
+		val updatedDeltaker = dbo.toDeltaker(statusConverterMock).update(updatedStatus, updatedStartDato, updatedSluttDato)
 		val updated = DeltakerDbo(updatedDeltaker)
 
 

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/GjennomforingControllerIntegrationTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/GjennomforingControllerIntegrationTest.kt
@@ -199,7 +199,7 @@ class GjennomforingControllerIntegrationTest {
 		deltakerStatusRepository.upsert(
 			DeltakerStatusDbo(
 			deltakerId = deltakerId,
-			endretDato = LocalDate.now().minusDays(1),
+			endretDato = LocalDateTime.now().minusDays(1),
 			status = Deltaker.Status.DELTAR,
 			aktiv = true
 		))

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/GjennomforingControllerTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/GjennomforingControllerTest.kt
@@ -43,7 +43,7 @@ class GjennomforingControllerTest {
 			DeltakerStatusDbo(
 				deltakerId = id,
 				status = Deltaker.Status.DELTAR,
-				endretDato = LocalDate.now(),
+				endretDato = LocalDateTime.now(),
 				aktiv = true)
 		)
 


### PR DESCRIPTION
- Retter feil som gjør at når bruker får samme status for andre gang, så vil det feile på databaseconstraint på deltaker+status+statusdato som var date isteden for datetime som da feiler hvis man får samme status igjen etter å ha hatt en annen status tidligere (siste test feilet)
- Manglet status endret dato når man gjorde oppdateringer
- Renamer metode updateStatus som oppdaterer flere ting enn status


https://trello.com/c/qGcOlwx2/212-feil-hvis-man-bytter-til-samme-status-igjen-etter-opphold