### PR TITLE
Oppdaterer informasjon om deltaker når vi får endringer fra kafka

### DIFF
--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Deltaker.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Deltaker.kt
@@ -22,25 +22,16 @@ data class Deltaker(
 		VENTER_PA_OPPSTART, DELTAR, HAR_SLUTTET, IKKE_AKTUELL
 	}
 
-	fun update(
-		newStatus: Status,
-		newDeltakerStartDato: LocalDate?,
-		newDeltakerSluttDato: LocalDate?,
-		newStatusEndretDato: LocalDateTime = LocalDateTime.now()
-	): Deltaker {
+	fun oppdater(nyDeltaker: Deltaker) : Deltaker {
+		if (nyDeltaker.id != id) throw IllegalStateException("Kan ikke oppdatere deltaker id ${id} med en annen deltaker id")
+		return nyDeltaker.copy(
+			statuser = oppdaterStatus(nyDeltaker.status, nyDeltaker.statuser.current.endretDato),
+			bruker = bruker
+		)
+	}
 
-		return if (statuser.current.status != newStatus
-			|| startDato != newDeltakerStartDato
-			|| sluttDato != newDeltakerSluttDato
-		) {
-
-			copy(
-				startDato = newDeltakerStartDato,
-				sluttDato = newDeltakerSluttDato,
-				statuser = if(statuser.current.status == newStatus) statuser else statuser.medNy(newStatus, newStatusEndretDato),
-			)
-
-		} else this
+	fun oppdaterStatus(newStatus: Status, newStatusEndretDato: LocalDateTime = LocalDateTime.now()): DeltakerStatuser {
+		return if (statuser.current.status != newStatus) statuser.medNy(newStatus, newStatusEndretDato) else statuser
 	}
 
 	fun progressStatus(): Deltaker {

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/repositories/DeltakerRepository.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/repositories/DeltakerRepository.kt
@@ -98,6 +98,8 @@ open class DeltakerRepository(
 			UPDATE deltaker
 			SET start_dato = :startDato,
 				slutt_dato    = :sluttDato,
+				dager_per_uke = :dagerPerUke,
+				prosent_stilling = :prosentStilling,
 				modified_at   = :modifiedAt
 			WHERE id = :deltakerInternalId
 	""".trimIndent()
@@ -106,6 +108,8 @@ open class DeltakerRepository(
 			mapOf(
 				"startDato" to deltaker.startDato,
 				"sluttDato" to deltaker.sluttDato,
+				"dagerPerUke" to deltaker.dagerPerUke,
+				"prosentStilling" to deltaker.prosentStilling,
 				"modifiedAt" to deltaker.modifiedAt,
 				"deltakerInternalId" to deltaker.id
 			)

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
@@ -29,7 +29,7 @@ open class DeltakerServiceImpl(
 			createDeltaker(fodselsnummer, gjennomforingId, deltaker)
 		} else {
 			val lagretDeltaker = lagretDeltakerDbo.toDeltaker(deltakerStatusRepository::getStatuserForDeltaker)
-			val oppdatertDeltaker = lagretDeltaker.update(deltaker.status, deltaker.startDato, deltaker.sluttDato, deltaker.statuser.current.endretDato)
+			val oppdatertDeltaker = lagretDeltaker.oppdater(deltaker)
 
 			if (lagretDeltaker != oppdatertDeltaker) {
 				deltakerStatusRepository.upsert(DeltakerStatusDbo.fromDeltaker(oppdatertDeltaker))

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/repositories/DeltakerRepositoryTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/repositories/DeltakerRepositoryTest.kt
@@ -98,21 +98,22 @@ internal class DeltakerRepositoryTest : FunSpec({
 			registrertDato
 		)
 
-		val updatedStartDato = LocalDate.now().plusDays(1)
-		val updatedSluttDato = LocalDate.now().plusDays(14)
-		val updatedStatus = Deltaker.Status.DELTAR
+		val nyStartdato = LocalDate.now().plusDays(1)
+		val nySluttdato = LocalDate.now().plusDays(14)
 
-		val updatedDeltaker = dbo.toDeltaker(statusConverterMock).update(updatedStatus, updatedStartDato, updatedSluttDato)
-		val updated = DeltakerDbo(updatedDeltaker)
+		val deltakerMedStatus = dbo.toDeltaker(statusConverterMock).let {
+			it.oppdater(it.copy(startDato = nyStartdato, sluttDato = nySluttdato))
+		}
+		val deltakerToInsert = DeltakerDbo(deltakerMedStatus)
 
 
-		updatedDeltaker shouldNotBe dbo.toDeltaker(statusConverterMock)
+		deltakerMedStatus shouldNotBe dbo.toDeltaker(statusConverterMock)
 
-		val updatedDbo = repository.update(updated)
+		val insertedDeltaker = repository.update(deltakerToInsert)
 
-		updatedDbo.id shouldBe dbo.id
-		updatedDbo.startDato shouldBe updatedStartDato
-		updatedDbo.sluttDato shouldBe updatedSluttDato
+		insertedDeltaker.id shouldBe dbo.id
+		insertedDeltaker.startDato shouldBe nyStartdato
+		insertedDeltaker.sluttDato shouldBe nySluttdato
 	}
 
 	test("Get by id") {


### PR DESCRIPTION
- Utvider integrasjonstest på konsumering så den validerer endringer på alle felter som potensielt kan endres
- Lagrer oppdateringer vi får på antall dager per uke og deltakelsesprosent, disse ble lagret tidligere men ikke oppdateringer på feltene
- Forenkler oppdatering av status `update`->`oppdaterStatus`. Status og fra og tildato skal oppdateres uavhengig av hverandre når vi får endringer fra kafka. Det kan hende vi må legge inn en sjekk på om den nye statusen er eldre enn den nye men det er ikke noe endring på det her.

https://trello.com/c/quUNbCb5/227-m%C3%A5-lagre-endringer-p%C3%A5-flere-felter-enn-status-og-fra-tildato