### PR TITLE
Deltaker hentes på id for å støtte at bruker er flere deltakere i sam…

### DIFF
--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
@@ -25,7 +25,7 @@ open class DeltakerServiceImpl(
 	}
 
 	override fun upsertDeltaker(fodselsnummer: String, gjennomforingId: UUID, deltaker: Deltaker) {
-		val lagretDeltakerDbo = deltakerRepository.get(fodselsnummer, gjennomforingId)
+		val lagretDeltakerDbo = deltakerRepository.get(deltaker.id)
 
 		if (lagretDeltakerDbo == null) {
 			createDeltaker(fodselsnummer, gjennomforingId, deltaker)

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/services/DeltakerServiceTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/services/DeltakerServiceTest.kt
@@ -72,7 +72,7 @@ class DeltakerServiceTest: StringSpec ({
 		val deltaker = defaultDeltaker
 		val deltakerDbo = defaultDeltakerDbo
 
-		every { deltakerRepository.get(fodselsnummer, gjennomforingId) } returns null
+		every { deltakerRepository.get(deltaker.id) } returns null
 		every { brukerService.getOrCreate(fodselsnummer) } returns defaultBruker.id
 		every { deltakerRepository.insert(any(), any(), any(), any(), any(), any(), any(), any()) } returns deltakerDbo
 		every { deltakerStatusRepository.upsert(any<List<DeltakerStatusDbo>>()) } returns Unit
@@ -106,7 +106,7 @@ class DeltakerServiceTest: StringSpec ({
 		val deltaker = defaultDeltaker.copy(statuser = DeltakerStatuser(nyStatus))
 		val deltakerDbo = defaultDeltakerDbo
 
-		every { deltakerRepository.get(fodselsnummer, gjennomforingId) } returns defaultDeltakerDbo
+		every { deltakerRepository.get(deltaker.id) } returns defaultDeltakerDbo
 		every { deltakerStatusRepository.getStatuserForDeltaker(defaultDeltakerDbo.id) } returns
 			deltakerStatusDboer(eksisterendeStatuser, deltaker.id)
 


### PR DESCRIPTION
…me tiltak
Skjer innimellom i testmiljø at bruker har ny deltaker på samme tiltak. Mulig det er noe feil i acl men burde støttes uansett.
ref: https://logs.adeo.no/app/discover#/doc/96e648c0-980a-11e9-830a-e17bbd64b4db/logstash-apps-test-001988?id=KX6-934B5-mg958HWjG2

https://trello.com/c/o1pzPF1W/248-deltaker-kan-ha-flere-deltakerid-p%C3%A5-samme-gjennomf%C3%B8ring