### PR TITLE
Eksponere arrangør

### DIFF
--- a/arrangor/src/main/kotlin/no/nav/amt/tiltak/arrangor/ArrangorRepository.kt
+++ b/arrangor/src/main/kotlin/no/nav/amt/tiltak/arrangor/ArrangorRepository.kt
@@ -86,4 +86,30 @@ open class ArrangorRepository(
             .firstOrNull()
     }
 
+	fun getById(id: UUID): ArrangorDbo {
+		return getNullableArrangor(id)?: throw IllegalStateException("Arrangør med id=$id eksisterer ikke")
+	}
+
+	fun getNullableArrangor(id: UUID): ArrangorDbo? {
+		val sql = """
+			SELECT id,
+				   overordnet_enhet_organisasjonsnummer,
+				   overordnet_enhet_navn,
+				   organisasjonsnummer,
+				   navn,
+				   created_at,
+				   modified_at
+			FROM arrangor
+			WHERE id = :id
+		""".trimIndent()
+
+		val parameters = MapSqlParameterSource().addValues(
+			mapOf(
+				"id" to id
+			)
+		)
+
+		return template.query(sql, parameters, rowMapper)
+			.firstOrNull()
+	}
 }

--- a/arrangor/src/main/kotlin/no/nav/amt/tiltak/arrangor/ArrangorService.kt
+++ b/arrangor/src/main/kotlin/no/nav/amt/tiltak/arrangor/ArrangorService.kt
@@ -26,6 +26,10 @@ class ArrangorService(
 		).toArrangor()
 	}
 
+	override fun getArrangorById(id: UUID): Arrangor {
+		return arrangorRepository.getById(id).toArrangor()
+	}
+
 	override fun getArrangorByVirksomhetsnummer(virksomhetsnummer: String): Arrangor? {
 		return arrangorRepository.getByOrganisasjonsnummer(virksomhetsnummer)?.toArrangor()
 	}

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Gjennomforing.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Gjennomforing.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.tiltak.core.domain.tiltak
 
+import no.nav.amt.tiltak.core.domain.arrangor.Arrangor
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
@@ -7,7 +8,7 @@ import java.util.*
 data class Gjennomforing(
 	val id: UUID,
 	val tiltak: Tiltak,
-	val arrangorId: UUID,
+	val arrangor: Arrangor,
 	val navn: String,
 	val status: Status,
 	val startDato: LocalDate?,

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/ArrangorService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/ArrangorService.kt
@@ -16,4 +16,6 @@ interface ArrangorService {
 
 	fun getArrangorByVirksomhetsnummer(virksomhetsnummer: String): Arrangor?
 
+	fun getArrangorById(id: UUID): Arrangor
+
 }

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/GjennomforingService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/GjennomforingService.kt
@@ -1,8 +1,6 @@
 package no.nav.amt.tiltak.core.port
 
 import no.nav.amt.tiltak.core.domain.tiltak.Gjennomforing
-import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.*
 
 interface GjennomforingService {
@@ -11,17 +9,7 @@ interface GjennomforingService {
 
 	fun getGjennomforinger(gjennomforingIder: List<UUID>): List<Gjennomforing>
 
-	fun upsertGjennomforing(
-		id: UUID,
-		tiltakId: UUID,
-		arrangorId: UUID,
-		navn: String,
-		status: Gjennomforing.Status,
-		startDato: LocalDate?,
-		sluttDato: LocalDate?,
-		registrertDato: LocalDateTime,
-		fremmoteDato: LocalDateTime?
-	): Gjennomforing
+	fun upsert(gjennomforing: Gjennomforing): Gjennomforing
 
 	fun slettGjennomforing(gjennomforingId: UUID)
 

--- a/ingestors/arena-acl-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena_acl_ingestor/processor/GjennomforingProcessor.kt
+++ b/ingestors/arena-acl-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena_acl_ingestor/processor/GjennomforingProcessor.kt
@@ -28,22 +28,23 @@ class GjennomforingProcessor(
 
 	private fun upsert(message: MessageWrapper<GjennomforingPayload>) {
 		val gjennomforing = message.payload
-		val tiltak = gjennomforing.tiltak
+		val tiltakPayload = gjennomforing.tiltak
 
 		val arrangor = arrangorService.upsertArrangor(gjennomforing.virksomhetsnummer)
+		val tiltak = tiltakService.upsertTiltak(tiltakPayload.id, tiltakPayload.navn, tiltakPayload.kode)
 
-		tiltakService.upsertTiltak(tiltak.id, tiltak.navn, tiltak.kode)
-
-		gjennomforingService.upsertGjennomforing(
-			id = gjennomforing.id,
-			tiltakId = gjennomforing.tiltak.id,
-			arrangorId = arrangor.id,
-			navn = gjennomforing.navn,
-			status = mapGjennomforingStatus(gjennomforing.status),
-			startDato = gjennomforing.startDato,
-			sluttDato = gjennomforing.sluttDato,
-			registrertDato = gjennomforing.registrertDato,
-			fremmoteDato = gjennomforing.fremmoteDato
+		gjennomforingService.upsert(
+			Gjennomforing(
+				id = gjennomforing.id,
+				tiltak = tiltak,
+				arrangor = arrangor,
+				navn = gjennomforing.navn,
+				status = mapGjennomforingStatus(gjennomforing.status),
+				startDato = gjennomforing.startDato,
+				sluttDato = gjennomforing.sluttDato,
+				registrertDato = gjennomforing.registrertDato,
+				fremmoteDato = gjennomforing.fremmoteDato
+			)
 		)
 
 		log.info("Fullført upsert av gjennomføring id=${gjennomforing.id} arrangorId=${arrangor.id}")

--- a/ingestors/arena-acl-ingestor/src/test/kotlin/no/nav/amt/tiltak/ingestors/arena_acl_ingestor/IntegrationTest.kt
+++ b/ingestors/arena-acl-ingestor/src/test/kotlin/no/nav/amt/tiltak/ingestors/arena_acl_ingestor/IntegrationTest.kt
@@ -89,9 +89,9 @@ class IntegrationTest {
 		tiltakService = TiltakServiceImpl(tiltakRepository)
 		brukerService = BrukerServiceImpl(brukerRepository, navKontorRepository, navKontorService, personService, mockk())
 		deltakerService = DeltakerServiceImpl(deltakerRepository, deltakerStatusRepository, brukerService, transactionTemplate)
-		gjennomforingService = GjennomforingServiceImpl(gjennomforingRepository, tiltakService, deltakerService, transactionTemplate)
-		deltakerProcessor = DeltakerProcessor(gjennomforingService, deltakerService, personService)
 		arrangorService = no.nav.amt.tiltak.arrangor.ArrangorService(mockk(), enhetsregisterClient, arrangorRepository)
+		gjennomforingService = GjennomforingServiceImpl(gjennomforingRepository, tiltakService, deltakerService, arrangorService, transactionTemplate)
+		deltakerProcessor = DeltakerProcessor(gjennomforingService, deltakerService, personService)
 
 		gjennomforingProcessor = GjennomforingProcessor(arrangorService, gjennomforingService, tiltakService)
 		ingestor = ArenaAclIngestorImpl(deltakerProcessor, gjennomforingProcessor)

--- a/test/database/pom.xml
+++ b/test/database/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>no.nav.amt-tiltak</groupId>
+            <artifactId>core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/commands/InsertArrangorCommand.kt
+++ b/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/commands/InsertArrangorCommand.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.tiltak.test.database.data.commands
 
+import no.nav.amt.tiltak.core.domain.arrangor.Arrangor
 import java.util.*
 
 data class InsertArrangorCommand(
@@ -8,4 +9,15 @@ data class InsertArrangorCommand(
 	val overordnet_enhet_navn: String?,
 	val organisasjonsnummer: String,
 	val navn: String
-)
+) {
+	fun toArrangor() : Arrangor {
+		return Arrangor(
+			id = this.id,
+			navn = this.navn,
+			organisasjonsnummer = this.organisasjonsnummer,
+			overordnetEnhetOrganisasjonsnummer = this.overordnet_enhet_organisasjonsnummer,
+			overordnetEnhetNavn = this.overordnet_enhet_navn
+		)
+	}
+
+}

--- a/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/commands/InsertGjennomforingCommand.kt
+++ b/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/commands/InsertGjennomforingCommand.kt
@@ -1,5 +1,8 @@
 package no.nav.amt.tiltak.test.database.data.commands
 
+import no.nav.amt.tiltak.core.domain.arrangor.Arrangor
+import no.nav.amt.tiltak.core.domain.tiltak.Gjennomforing
+import no.nav.amt.tiltak.core.domain.tiltak.Tiltak
 import java.time.LocalDate
 import java.util.*
 
@@ -13,4 +16,18 @@ data class InsertGjennomforingCommand(
 	val slutt_dato: LocalDate,
 	val registrert_dato: LocalDate,
 	val fremmote_dato: LocalDate
-)
+) {
+	fun toGjennomforing(tiltak: Tiltak, arrangor: Arrangor): Gjennomforing {
+		return Gjennomforing(
+			id = this.id,
+				tiltak = tiltak,
+				arrangor = arrangor,
+				navn = this.navn,
+				status = Gjennomforing.Status.valueOf(this.status),
+				startDato = this.start_dato,
+				sluttDato = this.slutt_dato,
+				registrertDato = this.registrert_dato.atStartOfDay(),
+				fremmoteDato = this.fremmote_dato.atStartOfDay()
+		)
+	}
+}

--- a/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/commands/InsertTiltakCommand.kt
+++ b/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/commands/InsertTiltakCommand.kt
@@ -1,9 +1,19 @@
 package no.nav.amt.tiltak.test.database.data.commands
 
+import no.nav.amt.tiltak.core.domain.tiltak.Tiltak
 import java.util.*
 
 data class InsertTiltakCommand(
 	val id: UUID,
 	val navn: String,
 	val type: String
-)
+) {
+	fun toTiltak(): Tiltak {
+		return Tiltak(
+			id = this.id,
+			kode = this.type,
+			navn = this.navn
+		)
+	}
+}
+

--- a/tiltak/pom.xml
+++ b/tiltak/pom.xml
@@ -121,6 +121,11 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
+        <dependency>
+            <groupId>no.nav.amt-tiltak</groupId>
+            <artifactId>arrangor</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/controllers/TiltakDeltakerPresentationService.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/controllers/TiltakDeltakerPresentationService.kt
@@ -55,6 +55,10 @@ open class TiltakDeltakerPresentationService(
 				tiltak = TiltakDto(
 					tiltaksnavn = tiltakNavn,
 					tiltakskode = tiltakKode
+				),
+				arrangor = ArrangorDto(
+					virksomhetNavn = virksomhetNavn,
+					organisasjonNavn = organisasjonNavn
 				)
 			)
 		)

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/dbo/DeltakerDetaljerDbo.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/dbo/DeltakerDetaljerDbo.kt
@@ -29,5 +29,7 @@ data class DeltakerDetaljerDbo(
 	val gjennomforingSluttDato: LocalDate?,
 	val gjennomforingStatus: Gjennomforing.Status?,
 	val tiltakNavn: String,
-	val tiltakKode: String
+	val tiltakKode: String,
+	val virksomhetNavn: String,
+	val organisasjonNavn: String?,
 )

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/repositories/DeltakerDetaljerRepository.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/repositories/DeltakerDetaljerRepository.kt
@@ -40,34 +40,38 @@ class GetDeltakerDetaljerQuery(
 			gjennomforingStatus = rs.getString("gjennomforing_status")?.let { Gjennomforing.Status.valueOf(it) },
 			tiltakNavn = rs.getString("tiltak_navn"),
 			tiltakKode = rs.getString("tiltak_kode"),
+			virksomhetNavn = rs.getString("virksomhet_navn"),
+			organisasjonNavn = rs.getString("organisasjon_navn")
 		)
 	}
 
 	private val sql = """
-		SELECT deltaker.id                  AS deltaker_id,
-			   deltaker.start_dato          AS start_dato,
-			   deltaker.slutt_dato          AS slutt_dato,
-			   deltaker_status.status       AS status,
-			   deltaker_status.endret_dato 	AS status_endret_dato,
-			   deltaker.registrert_dato     AS registrert_dato,
-			   bruker.fornavn               AS fornavn,
-			   bruker.mellomnavn            AS mellomnavn,
-			   bruker.etternavn             AS etternavn,
-			   bruker.fodselsnummer         AS fodselsnummer,
-			   bruker.telefonnummer         AS telefonnummer,
-			   bruker.epost                 AS epost,
-			   bruker.nav_kontor_id         AS nav_kontor_id,
-			   nav_kontor.navn				AS nav_kontor_navn,
-			   nav_ansatt.navn           	AS veileder_navn,
-			   nav_ansatt.telefonnummer     AS veileder_telefonnummer,
-			   nav_ansatt.epost             AS veileder_epost,
-			   gjennomforing.id             AS gjennomforing_id,
-			   gjennomforing.navn           AS gjennomforing_navn,
-			   gjennomforing.start_dato     AS gjennomforing_start_dato,
-			   gjennomforing.slutt_dato     AS gjennomforing_slutt_dato,
-			   gjennomforing.status         AS gjennomforing_status,
-			   tiltak.navn                  AS tiltak_navn,
-			   tiltak.type                  AS tiltak_kode
+		SELECT deltaker.id                  	AS deltaker_id,
+			   deltaker.start_dato          	AS start_dato,
+			   deltaker.slutt_dato          	AS slutt_dato,
+			   deltaker_status.status       	AS status,
+			   deltaker_status.endret_dato 		AS status_endret_dato,
+			   deltaker.registrert_dato     	AS registrert_dato,
+			   bruker.fornavn               	AS fornavn,
+			   bruker.mellomnavn            	AS mellomnavn,
+			   bruker.etternavn             	AS etternavn,
+			   bruker.fodselsnummer         	AS fodselsnummer,
+			   bruker.telefonnummer         	AS telefonnummer,
+			   bruker.epost                 	AS epost,
+			   bruker.nav_kontor_id         	AS nav_kontor_id,
+			   nav_kontor.navn					AS nav_kontor_navn,
+			   nav_ansatt.navn           		AS veileder_navn,
+			   nav_ansatt.telefonnummer     	AS veileder_telefonnummer,
+			   nav_ansatt.epost             	AS veileder_epost,
+			   gjennomforing.id             	AS gjennomforing_id,
+			   gjennomforing.navn           	AS gjennomforing_navn,
+			   gjennomforing.start_dato     	AS gjennomforing_start_dato,
+			   gjennomforing.slutt_dato     	AS gjennomforing_slutt_dato,
+			   gjennomforing.status         	AS gjennomforing_status,
+			   tiltak.navn                  	AS tiltak_navn,
+			   tiltak.type                  	AS tiltak_kode,
+			   arrangor.navn					AS virksomhet_navn,
+			   arrangor.overordnet_enhet_navn	AS organisasjon_navn
 		FROM deltaker
 				 LEFT JOIN bruker ON bruker.id = deltaker.bruker_id
 				 LEFT JOIN nav_ansatt ON nav_ansatt.id = bruker.ansvarlig_veileder_id
@@ -75,6 +79,7 @@ class GetDeltakerDetaljerQuery(
 				 LEFT JOIN gjennomforing ON gjennomforing.id = deltaker.gjennomforing_id
 				 LEFT JOIN tiltak ON gjennomforing.tiltak_id = tiltak.id
 				 LEFT JOIN deltaker_status ON deltaker_status.deltaker_id = deltaker.id
+				 LEFT JOIN arrangor on gjennomforing.arrangor_id = arrangor.id
 		WHERE deltaker.id = :deltakerId AND deltaker_status.aktiv
 	""".trimIndent()
 

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/dbo/GjennomforingDbo.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/dbo/GjennomforingDbo.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.tiltak.tiltak.dbo
 
+import no.nav.amt.tiltak.core.domain.arrangor.Arrangor
 import no.nav.amt.tiltak.core.domain.tiltak.Gjennomforing
 import no.nav.amt.tiltak.core.domain.tiltak.Tiltak
 import no.nav.amt.tiltak.utils.UpdateCheck
@@ -22,11 +23,11 @@ data class GjennomforingDbo(
     val modifiedAt: LocalDateTime
 ) {
 
-	fun toGjennomforing(tiltak: Tiltak): Gjennomforing {
+	fun toGjennomforing(tiltak: Tiltak, arrangor: Arrangor): Gjennomforing {
 		return Gjennomforing(
 			id = id,
 			tiltak = tiltak,
-			arrangorId = arrangorId,
+			arrangor = arrangor,
 			navn = navn,
 			status = status,
 			startDato = startDato,

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/dto/ArrangorDto.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/dto/ArrangorDto.kt
@@ -1,0 +1,13 @@
+package no.nav.amt.tiltak.tiltak.dto
+
+import no.nav.amt.tiltak.core.domain.arrangor.Arrangor
+
+class ArrangorDto (
+	val virksomhetNavn: String,
+	val organisasjonNavn: String?,
+)
+
+fun Arrangor.toDto() = ArrangorDto (
+	virksomhetNavn = navn,
+	organisasjonNavn = overordnetEnhetNavn
+)

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/dto/GjennomforingDto.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/dto/GjennomforingDto.kt
@@ -10,7 +10,8 @@ data class GjennomforingDto(
 	val startDato: LocalDate?,
 	val sluttDato: LocalDate?,
 	val status: Gjennomforing.Status?,
-	val tiltak: TiltakDto
+	val tiltak: TiltakDto,
+	val arrangor: ArrangorDto
 )
 
 fun Gjennomforing.toDto() = GjennomforingDto(
@@ -19,5 +20,6 @@ fun Gjennomforing.toDto() = GjennomforingDto(
 	startDato = this.startDato,
 	sluttDato = this.sluttDato,
 	status = this.status,
-	tiltak = this.tiltak.toDto()
+	tiltak = this.tiltak.toDto(),
+	arrangor = this.arrangor.toDto()
 )

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/controllers/TiltakDeltakerControllerTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/controllers/TiltakDeltakerControllerTest.kt
@@ -80,6 +80,10 @@ class TiltakDeltakerControllerTest {
 			tiltak = TiltakDto(
 				tiltakskode = "",
 				tiltaksnavn = ""
+			),
+			arrangor = ArrangorDto(
+				virksomhetNavn = "",
+				organisasjonNavn = null
 			)
 		)
 	)

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/GjennomforingControllerTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/GjennomforingControllerTest.kt
@@ -1,6 +1,7 @@
 package no.nav.amt.tiltak.tiltak.controllers
 
 import no.nav.amt.tiltak.common.auth.AuthService
+import no.nav.amt.tiltak.core.domain.arrangor.Arrangor
 import no.nav.amt.tiltak.core.domain.tiltak.Deltaker
 import no.nav.amt.tiltak.core.domain.tiltak.Gjennomforing
 import no.nav.amt.tiltak.core.domain.tiltak.Tiltak
@@ -83,7 +84,7 @@ class GjennomforingControllerTest {
 	val gjennomforing = Gjennomforing(
 		id = UUID.randomUUID(),
 		tiltak = tiltak,
-		arrangorId = UUID.randomUUID(),
+		arrangor = Arrangor(UUID.randomUUID(), "", "", "", ""),
 		navn = "tiltaksnavn",
 		fremmoteDato = LocalDateTime.now(),
 		startDato = LocalDate.now(),

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/services/GjennomforingServiceImplTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/services/GjennomforingServiceImplTest.kt
@@ -60,6 +60,7 @@ class GjennomforingServiceImplTest : FunSpec({
 				mockk(),
 				transactionTemplate
 			),
+			arrangorService = mockk(),
 			transactionTemplate = transactionTemplate
 		)
 


### PR DESCRIPTION
- Legger til informaasjon om arrangør til endepunktet som returnerer gjennomføringer og deltakerdetaljer(som allerede returnerer gjennomføring)
- Sender domeneobjektet Gjennomforing til upserten i `GjennomføringService` siden denne tar inn de samme feiltene. Henter arrangør og tiltak en gang Processor og sender videre isteden for å hente to ganger som det var lagt opp til

https://trello.com/c/yB6Hy5YH/296-virksomhetsvelgeren-d%C3%B8r