### PR TITLE
Lagt tilrette for at veiledere skal kunne autentisere seg …

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -34,6 +34,12 @@ spec:
   azure:
     application:
       enabled: true
+      allowAllUsers: false
+      claims:
+        groups:
+          - id: "f12fa5d6-ef0c-41db-80c9-5c9696bb5c14"
+        extra:
+          - "NAVident"
   tokenx:
     enabled: true
   accessPolicy:

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -34,6 +34,12 @@ spec:
   azure:
     application:
       enabled: true
+      allowAllUsers: false
+      claims:
+        groups:
+          - id: "ace70121-3382-47b0-a91d-f20a6b481a70"
+        extra:
+          - "NAVident"
   tokenx:
     enabled: true
   accessPolicy:

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -37,6 +37,9 @@ veilarboppfolging.scope=${VEILARBOPPFOLGING_SCOPE:null}
 no.nav.security.jwt.issuer.tokenx.discovery-url=${TOKEN_X_WELL_KNOWN_URL:null}
 no.nav.security.jwt.issuer.tokenx.accepted-audience=${TOKEN_X_CLIENT_ID:null}
 
+no.nav.security.jwt.issuer.azuread.discovery-url=${AZURE_APP_WELL_KNOWN_URL:null}
+no.nav.security.jwt.issuer.azuread.accepted-audience=${AZURE_APP_CLIENT_ID:null}
+
 spring.datasource.url=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}

--- a/arrangor/src/main/kotlin/no/nav/amt/tiltak/ansatt/TiltakarrangorAnsattController.kt
+++ b/arrangor/src/main/kotlin/no/nav/amt/tiltak/ansatt/TiltakarrangorAnsattController.kt
@@ -1,20 +1,21 @@
 package no.nav.amt.tiltak.ansatt
 
 import no.nav.amt.tiltak.common.auth.AuthService
+import no.nav.amt.tiltak.common.auth.Issuer
 import no.nav.amt.tiltak.core.port.ArrangorService
-import no.nav.security.token.support.core.api.Protected
+import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api/arrangor/ansatt")
-class AnsattController(
+@RequestMapping(value = [ "/api/arrangor/ansatt", "/api/tiltakarrangor/ansatt" ])
+class TiltakarrangorAnsattController(
 	private val authService: AuthService,
 	private val service: ArrangorService
 ) {
 
-	@Protected
+	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@GetMapping("/meg")
 	fun getInnloggetAnsatt(): AnsattDto {
 		val personligIdent = authService.hentPersonligIdentTilInnloggetBruker()

--- a/arrangor/src/test/kotlin/no/nav/amt/tiltak/ansatt/TiltakarrangorAnsattControllerTest.kt
+++ b/arrangor/src/test/kotlin/no/nav/amt/tiltak/ansatt/TiltakarrangorAnsattControllerTest.kt
@@ -17,8 +17,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import java.util.*
 
 @ActiveProfiles("test")
-@WebMvcTest(controllers = [AnsattController::class])
-class AnsattControllerTest {
+@WebMvcTest(controllers = [TiltakarrangorAnsattController::class])
+class TiltakarrangorAnsattControllerTest {
 
 	companion object {
 		private val server = MockOAuth2Server()
@@ -47,7 +47,7 @@ class AnsattControllerTest {
 	@Test
 	fun `getInnloggetAnsatt() should return 401 when not authenticated`() {
 		val response = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/arrangor/ansatt/meg")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/ansatt/meg")
 		).andReturn().response
 
 		assertEquals(401, response.status)
@@ -69,7 +69,7 @@ class AnsattControllerTest {
 			))
 
 		val response = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/arrangor/ansatt/meg")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/ansatt/meg")
 				.header("Authorization", "Bearer $token")
 		).andReturn().response
 

--- a/common/auth/src/main/kotlin/no/nav/amt/tiltak/common/auth/Issuer.kt
+++ b/common/auth/src/main/kotlin/no/nav/amt/tiltak/common/auth/Issuer.kt
@@ -1,0 +1,6 @@
+package no.nav.amt.tiltak.common.auth
+
+object Issuer {
+	const val TOKEN_X = "tokenx"
+	const val AZURE_AD = "azuread"
+}

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/controllers/TiltakarrangorDeltakerController.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/controllers/TiltakarrangorDeltakerController.kt
@@ -1,9 +1,10 @@
 package no.nav.amt.tiltak.deltaker.controllers
 
 import no.nav.amt.tiltak.common.auth.AuthService
+import no.nav.amt.tiltak.common.auth.Issuer
 import no.nav.amt.tiltak.core.port.ArrangorAnsattTilgangService
 import no.nav.amt.tiltak.tiltak.dto.TiltakDeltakerDetaljerDto
-import no.nav.security.token.support.core.api.Protected
+import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -11,14 +12,14 @@ import org.springframework.web.bind.annotation.RestController
 import java.util.*
 
 @RestController
-@RequestMapping("/api/tiltak-deltaker")
-class TiltakDeltakerController(
+@RequestMapping(value = [ "/api/tiltak-deltaker", "/api/tiltakarrangor/tiltak-deltaker" ])
+class TiltakarrangorDeltakerController(
 	private val deltakerPresentationService: TiltakDeltakerPresentationService,
 	private val authService: AuthService,
 	private val arrangorAnsattTilgangService: ArrangorAnsattTilgangService
 ) {
 
-	@Protected
+	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@GetMapping("/{tiltakDeltakerId}")
 	fun hentTiltakDeltakerDetaljer(@PathVariable("tiltakDeltakerId") deltakerId: UUID): TiltakDeltakerDetaljerDto {
 		val deltakerDetaljer = deltakerPresentationService.getDeltakerDetaljerById(deltakerId)

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/controllers/NavGjennomforingController.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/controllers/NavGjennomforingController.kt
@@ -1,0 +1,25 @@
+package no.nav.amt.tiltak.tiltak.controllers
+
+import no.nav.amt.tiltak.common.auth.Issuer
+import no.nav.amt.tiltak.tiltak.dto.GjennomforingDto
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(value = [ "/api/nav-ansatt/gjennomforing" ])
+class NavGjennomforingController() {
+
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	@ProtectedWithClaims(issuer = Issuer.AZURE_AD)
+	@GetMapping
+	fun hentGjennomforinger(): List<GjennomforingDto> {
+		log.info("Henter gjennomføringer for nav-ansatt. Ikke implementert enda")
+		return emptyList()
+	}
+
+
+}

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/controllers/TiltakarrangorGjennomforingController.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/controllers/TiltakarrangorGjennomforingController.kt
@@ -1,22 +1,26 @@
 package no.nav.amt.tiltak.tiltak.controllers
 
 import no.nav.amt.tiltak.common.auth.AuthService
+import no.nav.amt.tiltak.common.auth.Issuer
 import no.nav.amt.tiltak.core.port.ArrangorAnsattTilgangService
 import no.nav.amt.tiltak.core.port.DeltakerService
 import no.nav.amt.tiltak.core.port.GjennomforingService
 import no.nav.amt.tiltak.tiltak.dto.GjennomforingDto
 import no.nav.amt.tiltak.tiltak.dto.TiltakDeltakerDto
 import no.nav.amt.tiltak.tiltak.dto.toDto
-import no.nav.security.token.support.core.api.Protected
+import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 import java.util.*
 
 @RestController
-@RequestMapping("/api/gjennomforing")
-class GjennomforingController(
+@RequestMapping(value = [ "/api/gjennomforing", "/api/tiltakarrangor/gjennomforing" ])
+class TiltakarrangorGjennomforingController(
 	private val gjennomforingService: GjennomforingService,
 	private val deltakerService: DeltakerService,
 	private val authService: AuthService,
@@ -25,7 +29,7 @@ class GjennomforingController(
 
 	private val log = LoggerFactory.getLogger(javaClass)
 
-	@Protected
+	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@GetMapping
 	fun hentGjennomforinger(): List<GjennomforingDto> {
 		val ansattPersonligIdent = authService.hentPersonligIdentTilInnloggetBruker()
@@ -37,7 +41,7 @@ class GjennomforingController(
 			.map { it.toDto() }
 	}
 
-	@Protected
+	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@GetMapping("/{gjennomforingId}")
 	fun hentGjennomforing(@PathVariable("gjennomforingId") gjennomforingId: UUID): GjennomforingDto {
 		val ansattPersonligIdent = authService.hentPersonligIdentTilInnloggetBruker()
@@ -52,7 +56,7 @@ class GjennomforingController(
 		}
 	}
 
-	@Protected
+	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@GetMapping("/{gjennomforingId}/deltakere")
 	fun hentDeltakere(@PathVariable("gjennomforingId") gjennomforingId: UUID): List<TiltakDeltakerDto> {
 		val ansattPersonligIdent = authService.hentPersonligIdentTilInnloggetBruker()

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/controllers/TiltakarrangorDeltakerControllerTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/controllers/TiltakarrangorDeltakerControllerTest.kt
@@ -23,8 +23,8 @@ import java.time.LocalDateTime
 import java.util.*
 
 @ActiveProfiles("test")
-@WebMvcTest(controllers = [TiltakDeltakerController::class])
-class TiltakDeltakerControllerTest {
+@WebMvcTest(controllers = [TiltakarrangorDeltakerController::class])
+class TiltakarrangorDeltakerControllerTest {
 
 	companion object {
 		private val server = MockOAuth2Server()
@@ -32,6 +32,7 @@ class TiltakDeltakerControllerTest {
 		init {
 			server.start()
 			System.setProperty("MOCK_TOKEN_X_DISCOVERY_URL", server.wellKnownUrl("tokenx").toString())
+			System.setProperty("MOCK_AZURE_AD_DISCOVERY_URL", server.wellKnownUrl("azuread").toString())
 		}
 
 		@AfterAll
@@ -96,7 +97,7 @@ class TiltakDeltakerControllerTest {
 	@Test
 	fun `hentTiltakDeltakerDetaljer() should return 401 when not authenticated`() {
 		val response = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/tiltak-deltaker/$deltakerId")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/tiltak-deltaker/$deltakerId")
 		).andReturn().response
 
 		Assertions.assertEquals(401, response.status)
@@ -113,7 +114,7 @@ class TiltakDeltakerControllerTest {
 			.thenReturn(tiltakDeltakerDetaljerDto)
 
 		mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/tiltak-deltaker/$deltakerId")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/tiltak-deltaker/$deltakerId")
 				.header("Authorization", "Bearer $token")
 		).andReturn().response
 
@@ -130,7 +131,7 @@ class TiltakDeltakerControllerTest {
 			.thenReturn(tiltakDeltakerDetaljerDto)
 
 		val response = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/tiltak-deltaker/$deltakerId")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/tiltak-deltaker/$deltakerId")
 				.header("Authorization", "Bearer $token")
 		).andReturn().response
 

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/NavGjennomforingControllerTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/NavGjennomforingControllerTest.kt
@@ -1,0 +1,121 @@
+package no.nav.amt.tiltak.tiltak.controllers
+
+import no.nav.amt.tiltak.core.domain.arrangor.Arrangor
+import no.nav.amt.tiltak.core.domain.tiltak.Deltaker
+import no.nav.amt.tiltak.core.domain.tiltak.Gjennomforing
+import no.nav.amt.tiltak.core.domain.tiltak.Tiltak
+import no.nav.amt.tiltak.deltaker.dbo.DeltakerDbo
+import no.nav.amt.tiltak.deltaker.dbo.DeltakerStatusDbo
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.MockitoAnnotations
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = [NavGjennomforingController::class])
+class NavGjennomforingControllerTest {
+	private val gjennomforingId = UUID.fromString("e68d54e2-47b5-11ec-81d3-0242ac130003")
+
+	private val fnr = "fnr"
+
+	@Autowired
+	private lateinit var mockMvc: MockMvc
+
+	val statusConverterMock = fun (id: UUID) =
+		listOf(
+			DeltakerStatusDbo(
+				deltakerId = id,
+				status = Deltaker.Status.DELTAR,
+				endretDato = LocalDateTime.now(),
+				aktiv = true)
+		)
+
+	val deltakerDbo = DeltakerDbo(
+		id = UUID.randomUUID(),
+		brukerId = UUID.randomUUID(),
+		brukerFodselsnummer = "12129312375",
+		brukerFornavn = "Fornavn",
+		brukerEtternavn = "Etternavn",
+		gjennomforingId = gjennomforingId,
+		startDato = LocalDate.now(),
+		sluttDato = LocalDate.now(),
+		dagerPerUke = 1,
+		prosentStilling = 10.343f,
+		createdAt = LocalDateTime.now(),
+		modifiedAt = LocalDateTime.now(),
+		registrertDato = LocalDateTime.now()
+	)
+
+	val tiltak = Tiltak(
+		id = UUID.randomUUID(),
+		navn = "tiltaksnavn",
+		kode = "kode"
+	)
+	val gjennomforing = Gjennomforing(
+		id = UUID.randomUUID(),
+		tiltak = tiltak,
+		arrangor = Arrangor(UUID.randomUUID(), "", "", "", ""),
+		navn = "tiltaksnavn",
+		fremmoteDato = LocalDateTime.now(),
+		startDato = LocalDate.now(),
+		registrertDato = LocalDateTime.now(),
+		sluttDato = LocalDate.now(),
+		status = Gjennomforing.Status.GJENNOMFORES,
+	)
+
+	@BeforeEach
+	fun before() {
+		MockitoAnnotations.openMocks(this)
+	}
+
+	companion object {
+		private val server = MockOAuth2Server()
+
+		init {
+			server.start()
+			System.setProperty("MOCK_TOKEN_X_DISCOVERY_URL", server.wellKnownUrl("tokenx").toString())
+			System.setProperty("MOCK_AZURE_AD_DISCOVERY_URL", server.wellKnownUrl("azuread").toString())
+		}
+
+		@AfterAll
+		@JvmStatic
+		fun cleanup() {
+			server.shutdown()
+		}
+	}
+
+	@Test
+	fun `hentGjennomforingerForNavAnsatte() - sender med tokenx-token - skal returnere 401`() {
+		val token = server.issueToken("tokenx", "test", "test").serialize()
+
+		val response = mockMvc.perform(
+			MockMvcRequestBuilders.get("/api/nav-ansatt/gjennomforing")
+				.header("Authorization", "Bearer $token")
+		).andReturn().response
+
+		assertEquals(401, response.status)
+	}
+
+	@Test
+	fun `hentGjennomforingerForNavAnsatte() - sender med azure ad-token - skal returnere 200`() {
+		val token = server.issueToken("azuread", "test", "test").serialize()
+
+		val response = mockMvc.perform(
+			MockMvcRequestBuilders.get("/api/nav-ansatt/gjennomforing")
+				.header("Authorization", "Bearer $token")
+		).andReturn().response
+
+		assertEquals(200, response.status)
+	}
+
+}

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/TiltakarrangorGjennomforingControllerIntegrationTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/TiltakarrangorGjennomforingControllerIntegrationTest.kt
@@ -39,7 +39,7 @@ import java.time.temporal.ChronoUnit
 import java.util.*
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class GjennomforingControllerIntegrationTest {
+class TiltakarrangorGjennomforingControllerIntegrationTest {
 
 	private val dataSource = SingletonPostgresContainer.getDataSource()
 
@@ -54,7 +54,7 @@ class GjennomforingControllerIntegrationTest {
 	private lateinit var deltakerService: DeltakerService
 	private lateinit var arrangorService: ArrangorService
 	private lateinit var authService: AuthService
-	private lateinit var controller: GjennomforingController
+	private lateinit var controller: TiltakarrangorGjennomforingController
 	private var tiltakKode = "GRUPPEAMO"
 	private var epost = "bla@bla.com"
 
@@ -91,7 +91,7 @@ class GjennomforingControllerIntegrationTest {
 			arrangorService,
 			transactionTemplate
 		)
-		controller = GjennomforingController(
+		controller = TiltakarrangorGjennomforingController(
 			gjennomforingService, deltakerService,
 			authService, mock(ArrangorAnsattTilgangService::class.java)
 		)

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/TiltakarrangorGjennomforingControllerTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/controllers/TiltakarrangorGjennomforingControllerTest.kt
@@ -30,8 +30,8 @@ import java.time.LocalDateTime
 import java.util.*
 
 @ActiveProfiles("test")
-@WebMvcTest(controllers = [GjennomforingController::class])
-class GjennomforingControllerTest {
+@WebMvcTest(controllers = [TiltakarrangorGjennomforingController::class])
+class TiltakarrangorGjennomforingControllerTest {
 	private val gjennomforingId = UUID.fromString("e68d54e2-47b5-11ec-81d3-0242ac130003")
 
 	private val fnr = "fnr"
@@ -107,6 +107,7 @@ class GjennomforingControllerTest {
 		init {
 			server.start()
 			System.setProperty("MOCK_TOKEN_X_DISCOVERY_URL", server.wellKnownUrl("tokenx").toString())
+			System.setProperty("MOCK_AZURE_AD_DISCOVERY_URL", server.wellKnownUrl("azuread").toString())
 		}
 
 		@AfterAll
@@ -119,7 +120,7 @@ class GjennomforingControllerTest {
 	@Test
 	fun `hentGjennomforingerByArrangorId() should return 401 when not authenticated`() {
 		val response = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/gjennomforing")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/gjennomforing")
 				.queryParam("arrangorId", "test")
 		).andReturn().response
 
@@ -131,7 +132,7 @@ class GjennomforingControllerTest {
 		val token = server.issueToken("tokenx", "test", "test").serialize()
 
 		val response = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/gjennomforing")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/gjennomforing")
 				.queryParam("arrangorId", UUID.randomUUID().toString())
 				.header("Authorization", "Bearer $token")
 		).andReturn().response
@@ -142,7 +143,7 @@ class GjennomforingControllerTest {
 	@Test
 	fun `hentGjennomforing() should return 401 when not authenticated`() {
 		val response = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/gjennomforing/$gjennomforingId")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/gjennomforing/$gjennomforingId")
 		).andReturn().response
 
 		assertEquals(401, response.status)
@@ -155,7 +156,7 @@ class GjennomforingControllerTest {
 		Mockito.`when`(gjennomforingService.getGjennomforing(gjennomforingId)).thenReturn(gjennomforing)
 
 		val response = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/gjennomforing/$gjennomforingId")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/gjennomforing/$gjennomforingId")
 				.header("Authorization", "Bearer $token")
 		).andReturn().response
 
@@ -169,7 +170,7 @@ class GjennomforingControllerTest {
 		Mockito.`when`(gjennomforingService.getGjennomforing(gjennomforingId)).thenReturn(gjennomforing)
 
 		mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/gjennomforing/$gjennomforingId")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/gjennomforing/$gjennomforingId")
 				.header("Authorization", "Bearer $token")
 		).andReturn().response
 
@@ -181,7 +182,7 @@ class GjennomforingControllerTest {
 	@Test
 	fun `hentDeltakere() should return 401 when not authenticated`() {
 		val response = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/gjennomforing/ID/deltakere")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/gjennomforing/ID/deltakere")
 		).andReturn().response
 
 		assertEquals(401, response.status)
@@ -196,7 +197,7 @@ class GjennomforingControllerTest {
 		Mockito.`when`(deltakerService.hentDeltakerePaaGjennomforing(gjennomforingId)).thenReturn(listOf(deltaker))
 
 		val response = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/gjennomforing/$gjennomforingId/deltakere")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/gjennomforing/$gjennomforingId/deltakere")
 				.header("Authorization", "Bearer $token")
 		).andReturn().response
 
@@ -212,7 +213,7 @@ class GjennomforingControllerTest {
 		Mockito.`when`(deltakerService.hentDeltakerePaaGjennomforing(gjennomforingId)).thenReturn(listOf(deltaker))
 
 		mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/gjennomforing/$gjennomforingId/deltakere")
+			MockMvcRequestBuilders.get("/api/tiltakarrangor/gjennomforing/$gjennomforingId/deltakere")
 				.header("Authorization", "Bearer $token")
 		).andReturn().response
 

--- a/tiltak/src/test/resources/application-test.properties
+++ b/tiltak/src/test/resources/application-test.properties
@@ -1,3 +1,6 @@
 
 no.nav.security.jwt.issuer.tokenx.discovery-url=${MOCK_TOKEN_X_DISCOVERY_URL:null}
 no.nav.security.jwt.issuer.tokenx.accepted-audience=test
+
+no.nav.security.jwt.issuer.azuread.discovery-url=${MOCK_AZURE_AD_DISCOVERY_URL:null}
+no.nav.security.jwt.issuer.azuread.accepted-audience=test


### PR DESCRIPTION
… med azure ad, slik at tjenester også kan kalle endepunkter på vegne av veiledere. Har også eksponerte eksisterende endepuntker under ny url slik at det skal bli lettere å gruppere endepunkter for veiledere og tiltaksarragnører