### PR TITLE
Kall veilarboppfolging direkte

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -82,6 +82,8 @@ spec:
       value: "true"
     - name: VEILARBARENA_SCOPE
       value: api://dev-fss.pto.veilarbarena/.default
+    - name: VEILARBOPPFOLGING_URL
+      value: https://veilarboppfolging.dev-fss-pub.nais.io
     - name: VEILARBOPPFOLGING_SCOPE
       value: api://dev-fss.pto.veilarboppfolging/.default
     - name: DIGDIR_KRR_PROXY_SCOPE

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -84,6 +84,8 @@ spec:
       value: api://prod-fss.pto.veilarbarena/.default
     - name: VEILARBOPPFOLGING_SCOPE
       value: api://prod-fss.pto.veilarboppfolging/.default
+    - name: VEILARBOPPFOLGING_URL
+      value: https://veilarboppfolging.prod-fss-pub.nais.io
     - name: DIGDIR_KRR_PROXY_SCOPE
       value: api://prod-gcp.team-rocket.digdir-krr-proxy/.default
     - name: DIGDIR_KRR_PROXY_URL

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -40,6 +40,8 @@ veilarbarena.scope=${VEILARBARENA_SCOPE:null}
 
 veilarboppfolging.scope=${VEILARBOPPFOLGING_SCOPE:null}
 
+veilarboppfolging.url=${VEILARBOPPFOLGING_URL:null}
+
 poao-tilgang.url=${POAO_TILGANG_URL:null}
 poao-tilgang.scope=${POAO_TILGANG_SCOPE:null}
 

--- a/application/src/test/resources/application-local.properties
+++ b/application/src/test/resources/application-local.properties
@@ -36,6 +36,8 @@ digdir-krr-proxy.url=http://localhost:1234
 
 veilarbarena.scope=api://test.pto.veilarbarena/.default
 
+veilarbarena.url=http://localhost:1234
+
 veilarboppfolging.scope=api://test.pto.veilarboppfolging/.default
 
 spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5454}/${DB_DATABASE:amt-tiltak-db}

--- a/clients/veilarboppfolging/src/main/kotlin/no/nav/amt/tiltak/clients/veilarboppfolging/VeilarboppfolgingClientImpl.kt
+++ b/clients/veilarboppfolging/src/main/kotlin/no/nav/amt/tiltak/clients/veilarboppfolging/VeilarboppfolgingClientImpl.kt
@@ -7,7 +7,6 @@ import java.util.function.Supplier
 
 class VeilarboppfolgingClientImpl(
 	private val apiUrl: String,
-	private val proxyTokenProvider: Supplier<String>,
 	private val veilarboppfolgingTokenProvider: Supplier<String>,
 	private val httpClient: OkHttpClient = baseClient(),
 ) : VeilarboppfolgingClient {
@@ -16,8 +15,7 @@ class VeilarboppfolgingClientImpl(
 		val request = Request.Builder()
 			.url("$apiUrl/api/v2/veileder?fnr=$fnr")
 			.header("Accept", "application/json; charset=utf-8")
-			.header("Downstream-Authorization", "Bearer ${veilarboppfolgingTokenProvider.get()}")
-			.header("Authorization", "Bearer ${proxyTokenProvider.get()}")
+			.header("Authorization", "Bearer ${veilarboppfolgingTokenProvider.get()}")
 			.get()
 			.build()
 

--- a/clients/veilarboppfolging/src/main/kotlin/no/nav/amt/tiltak/clients/veilarboppfolging/VeilarboppfolgingConfig.kt
+++ b/clients/veilarboppfolging/src/main/kotlin/no/nav/amt/tiltak/clients/veilarboppfolging/VeilarboppfolgingConfig.kt
@@ -8,11 +8,8 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 open class VeilarboppfolgingConfig {
 
-	@Value("\${poao-gcp-proxy.url}")
+	@Value("\${veilarboppfolging.url}")
 	lateinit var url: String
-
-	@Value("\${poao-gcp-proxy.scope}")
-	lateinit var poaoGcpProxyScope: String
 
 	@Value("\${veilarboppfolging.scope}")
 	lateinit var veilarboppfolgingScope: String
@@ -20,8 +17,7 @@ open class VeilarboppfolgingConfig {
 	@Bean
 	open fun veilarboppfolgingClient(machineToMachineTokenClient: MachineToMachineTokenClient): VeilarboppfolgingClient {
 		return VeilarboppfolgingClientImpl(
-			apiUrl = "$url/proxy/veilarboppfolging",
-			proxyTokenProvider = { machineToMachineTokenClient.createMachineToMachineToken(poaoGcpProxyScope) },
+			apiUrl = "$url/veilarboppfolging",
 			veilarboppfolgingTokenProvider = { machineToMachineTokenClient.createMachineToMachineToken(veilarboppfolgingScope) }
 		)
 	}

--- a/clients/veilarboppfolging/src/test/kotlin/no/nav/amt-tiltak/connectors/veilarboppfolging/VeilarboppfolgingClientTest.kt
+++ b/clients/veilarboppfolging/src/test/kotlin/no/nav/amt-tiltak/connectors/veilarboppfolging/VeilarboppfolgingClientTest.kt
@@ -19,9 +19,19 @@ class VeilarboppfolgingClientTest: StringSpec({
 		val serverUrl = server.url("/api").toString()
         client = VeilarboppfolgingClientImpl(
 			apiUrl = serverUrl,
-			proxyTokenProvider = { proxyToken },
 			veilarboppfolgingTokenProvider = { veilarboppfolgingToken }
 		)
+	}
+
+	"HentVeilederIdent - Skal sende med authorization" {
+		val jsonRepons = """{"veilederIdent":"V123"}""".trimIndent()
+		server.enqueue(MockResponse().setBody(jsonRepons))
+
+		client.hentVeilederIdent(fnr)
+
+		val request = server.takeRequest()
+
+		request.getHeader("Authorization") shouldBe "Bearer VEILARBOPPFOLGING_TOKEN"
 	}
 
     "HentVeilederIdent - Bruker finnes - Returnerer veileder ident" {


### PR DESCRIPTION
Bruk public-ingress til veilarboppfolging isteden for å gå igjennom
poao-gcp-proxy.