### PR TITLE
Legg til endepunkt for å sende endringsmelding med sluttdato

### DIFF
--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/EndringsmeldingController.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/EndringsmeldingController.kt
@@ -35,6 +35,7 @@ class EndringsmeldingController(
 				EndringsmeldingDto(
 					id = it.id,
 					startDato = it.startDato,
+					sluttDato = it.sluttDato,
 					aktiv = it.aktiv
 				)
 			}
@@ -46,6 +47,23 @@ class EndringsmeldingController(
 		@PathVariable("deltakerId") deltakerId: UUID,
 		@RequestParam("startDato") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDato: LocalDate
 	) {
+		val ansattId = ansattIdForDeltaker(deltakerId)
+
+		endringsmeldingService.opprettMedStartDato(deltakerId, startDato, ansattId)
+	}
+
+	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
+	@PostMapping("/deltaker/{deltakerId}/sluttdato")
+	fun registrerSluttDato(
+		@PathVariable("deltakerId") deltakerId: UUID,
+		@RequestParam("sluttDato") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) sluttDato: LocalDate
+	) {
+		val ansattId = ansattIdForDeltaker(deltakerId)
+
+		endringsmeldingService.opprettMedSluttDato(deltakerId, sluttDato, ansattId)
+	}
+
+	private fun ansattIdForDeltaker(deltakerId: UUID): UUID {
 		val ansattPersonligIdent = authService.hentPersonligIdentTilInnloggetBruker()
 		val deltaker = deltakerService.hentDeltaker(deltakerId)
 			?: throw NoSuchElementException("Fant ikke deltaker med id $deltakerId")
@@ -58,8 +76,7 @@ class EndringsmeldingController(
 		if (erSkjermet) {
 			throw NotImplementedError("Støtte for denne personen er ikke implementert")
 		}
-
-		endringsmeldingService.opprettMedStartDato(deltakerId, startDato, ansattId)
+		return ansattId
 	}
 
 }

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/dto/AktivEndringsmeldingDto.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/dto/AktivEndringsmeldingDto.kt
@@ -4,9 +4,11 @@ import no.nav.amt.tiltak.core.domain.tiltak.Endringsmelding
 import java.time.LocalDate
 
 data class AktivEndringsmeldingDto(
-	val startDato: LocalDate?
+	val startDato: LocalDate?,
+	val sluttDato: LocalDate?,
 )
 
 fun Endringsmelding.toDto() = AktivEndringsmeldingDto(
-	startDato = startDato
+	startDato = startDato,
+	sluttDato = sluttDato,
 )

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/dto/EndringsmeldingDto.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/dto/EndringsmeldingDto.kt
@@ -6,5 +6,6 @@ import java.util.*
 data class EndringsmeldingDto(
 	val id: UUID,
 	val startDato: LocalDate?,
+	val sluttDato: LocalDate?,
 	val aktiv: Boolean,
 )

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Endringsmelding.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Endringsmelding.kt
@@ -9,9 +9,10 @@ data class Endringsmelding(
 	val id: UUID,
 	val deltakerId: UUID,
 	val startDato: LocalDate?,
+	val sluttDato: LocalDate?,
 	val ferdiggjortAvNavAnsattId: UUID?,
 	val ferdiggjortTidspunkt: ZonedDateTime?,
-	val aktiv: Boolean, // false hvis man sletter eller kommer en ny endring
+	val aktiv: Boolean,
 	val opprettetAvArrangorAnsattId: UUID,
 	val opprettet: LocalDateTime,
 )

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/EndringsmeldingService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/EndringsmeldingService.kt
@@ -16,6 +16,12 @@ interface EndringsmeldingService {
 		ansattId: UUID
 	): Endringsmelding
 
+	fun opprettMedSluttDato(
+		deltakerId: UUID,
+		sluttDato: LocalDate,
+		ansattId: UUID
+	): Endringsmelding
+
 	fun hentEndringsmeldingerForGjennomforing(gjennomforingId: UUID): List<Endringsmelding>
 
 	fun hentEndringsmeldingerForDeltaker(deltakerId: UUID): List<Endringsmelding>

--- a/db-migrations/src/main/resources/db/migration/V23__endringsmelding-sluttdato.sql
+++ b/db-migrations/src/main/resources/db/migration/V23__endringsmelding-sluttdato.sql
@@ -1,0 +1,2 @@
+ALTER TABLE endringsmelding
+ADD COLUMN slutt_dato date

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingDbo.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingDbo.kt
@@ -10,9 +10,10 @@ data class EndringsmeldingDbo(
 	val id: UUID,
 	val deltakerId: UUID,
 	val startDato: LocalDate?,
+	val sluttDato: LocalDate?,
 	val ferdiggjortAvNavAnsattId: UUID?,
 	val ferdiggjortTidspunkt: ZonedDateTime?,
-	val aktiv: Boolean, // false hvis man sletter eller kommer en ny endring
+	val aktiv: Boolean,
 	val opprettetAvArrangorAnsattId: UUID,
 	val createdAt: LocalDateTime,
 	val modifiedAt: LocalDateTime
@@ -23,6 +24,7 @@ data class EndringsmeldingDbo(
 			id = id,
 			deltakerId = deltakerId,
 			startDato = startDato,
+			sluttDato = sluttDato,
 			ferdiggjortAvNavAnsattId = ferdiggjortAvNavAnsattId,
 			ferdiggjortTidspunkt = ferdiggjortTidspunkt,
 			aktiv = aktiv,

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingRepository.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingRepository.kt
@@ -21,6 +21,7 @@ open class EndringsmeldingRepository(
 			id = rs.getUUID("id"),
 			deltakerId = rs.getUUID("deltaker_id"),
 			startDato = rs.getDate("start_dato")?.toLocalDate(),
+			sluttDato = rs.getDate("slutt_dato")?.toLocalDate(),
 			ferdiggjortAvNavAnsattId = rs.getNullableUUID("ferdiggjort_av_nav_ansatt_id"),
 			ferdiggjortTidspunkt = rs.getNullableZonedDateTime("ferdiggjort_tidspunkt"),
 			aktiv = rs.getBoolean("aktiv"),
@@ -103,35 +104,52 @@ open class EndringsmeldingRepository(
 
 	open fun insertOgInaktiverStartDato(startDato: LocalDate, deltakerId: UUID, opprettetAv: UUID): EndringsmeldingDbo {
 		return transactionTemplate.execute {
-			inaktiverTidligereMeldinger(deltakerId)
-			return@execute insertNyStartDato(startDato, deltakerId, opprettetAv)
+			inaktiverMeldingerMedStartDato(deltakerId)
+			return@execute insertNyDato(startDato, sluttDato = null, deltakerId, opprettetAv)
 		}!!
 	}
 
-	private fun inaktiverTidligereMeldinger(deltakerId: UUID): Int {
+	open fun insertOgInaktiverSluttDato(sluttDato: LocalDate, deltakerId: UUID, opprettetAv: UUID): EndringsmeldingDbo {
+		return transactionTemplate.execute {
+			inaktiverMeldingerMedSluttDato(deltakerId)
+			return@execute insertNyDato(startDato = null, sluttDato,  deltakerId, opprettetAv)
+		}!!
+	}
+
+	private fun inaktiverMeldingerMedStartDato(deltakerId: UUID): Int {
+		return inaktiverMeldingerMedDato(deltakerId, "start_dato")
+	}
+
+	private fun inaktiverMeldingerMedSluttDato(deltakerId: UUID): Int {
+		return inaktiverMeldingerMedDato(deltakerId, "slutt_dato")
+	}
+
+	private fun inaktiverMeldingerMedDato(deltakerId: UUID, datoColumn: String): Int {
 		val sql = """
-			UPDATE endringsmelding
-			SET aktiv = false
-			WHERE deltaker_id = :deltaker_id
-		""".trimIndent()
+				UPDATE endringsmelding
+				SET aktiv = false
+				WHERE deltaker_id = :deltaker_id AND $datoColumn IS NOT NULL
+			""".trimIndent()
 
 		val params = sqlParameters("deltaker_id" to deltakerId)
 
 		return template.update(sql, params)
 	}
 
-	private fun insertNyStartDato(startDato: LocalDate, deltakerId: UUID, opprettetAvArrangorAnsattId: UUID): EndringsmeldingDbo {
+
+	private fun insertNyDato(startDato: LocalDate?, sluttDato: LocalDate?, deltakerId: UUID, opprettetAvArrangorAnsattId: UUID): EndringsmeldingDbo {
 		val id = UUID.randomUUID()
 
 		val sql = """
-			INSERT INTO endringsmelding(id, deltaker_id, start_dato, aktiv, opprettet_av_arrangor_ansatt_id)
-			VALUES (:id, :deltaker_id, :start_dato, true, :opprettet_av)
+			INSERT INTO endringsmelding(id, deltaker_id, start_dato, slutt_dato, aktiv, opprettet_av_arrangor_ansatt_id)
+			VALUES (:id, :deltaker_id, :start_dato, :slutt_dato, true, :opprettet_av)
 		""".trimIndent()
 
 		val params = sqlParameters(
 			"id" to id,
 			"deltaker_id" to deltakerId,
 			"start_dato" to startDato,
+			"slutt_dato" to sluttDato,
 			"opprettet_av" to opprettetAvArrangorAnsattId
 		)
 

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingRepository.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingRepository.kt
@@ -104,27 +104,19 @@ open class EndringsmeldingRepository(
 
 	open fun insertOgInaktiverStartDato(startDato: LocalDate, deltakerId: UUID, opprettetAv: UUID): EndringsmeldingDbo {
 		return transactionTemplate.execute {
-			inaktiverMeldingerMedStartDato(deltakerId)
+			inaktiverMeldingerMedDato(deltakerId, "start_dato")
 			return@execute insertNyDato(startDato, sluttDato = null, deltakerId, opprettetAv)
 		}!!
 	}
 
 	open fun insertOgInaktiverSluttDato(sluttDato: LocalDate, deltakerId: UUID, opprettetAv: UUID): EndringsmeldingDbo {
 		return transactionTemplate.execute {
-			inaktiverMeldingerMedSluttDato(deltakerId)
+			inaktiverMeldingerMedDato(deltakerId, "slutt_dato")
 			return@execute insertNyDato(startDato = null, sluttDato,  deltakerId, opprettetAv)
 		}!!
 	}
 
-	private fun inaktiverMeldingerMedStartDato(deltakerId: UUID): Int {
-		return inaktiverMeldingerMedDato(deltakerId, "start_dato")
-	}
-
-	private fun inaktiverMeldingerMedSluttDato(deltakerId: UUID): Int {
-		return inaktiverMeldingerMedDato(deltakerId, "slutt_dato")
-	}
-
-	private fun inaktiverMeldingerMedDato(deltakerId: UUID, datoColumn: String): Int {
+	private fun inaktiverMeldingerMedDato(deltakerId: UUID, datoColumn: String) {
 		val sql = """
 				UPDATE endringsmelding
 				SET aktiv = false
@@ -133,7 +125,7 @@ open class EndringsmeldingRepository(
 
 		val params = sqlParameters("deltaker_id" to deltakerId)
 
-		return template.update(sql, params)
+		template.update(sql, params)
 	}
 
 

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingServiceImpl.kt
@@ -29,6 +29,10 @@ open class EndringsmeldingServiceImpl(
 		return endringsmeldingRepository.insertOgInaktiverStartDato(startDato, deltakerId, ansattId).toModel()
 	}
 
+	override fun opprettMedSluttDato(deltakerId: UUID, sluttDato: LocalDate, ansattId: UUID): Endringsmelding {
+		return endringsmeldingRepository.insertOgInaktiverSluttDato(sluttDato, deltakerId, ansattId).toModel()
+	}
+
 	override fun markerSomFerdig(endringsmeldingId: UUID, navAnsattId: UUID) {
 		val endringsmelding = endringsmeldingRepository.get(endringsmeldingId)
 

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingRepositoryTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingRepositoryTest.kt
@@ -9,7 +9,6 @@ import io.kotest.matchers.shouldNotBe
 import no.nav.amt.tiltak.test.database.DbTestDataUtils
 import no.nav.amt.tiltak.test.database.DbUtils.shouldBeCloseTo
 import no.nav.amt.tiltak.test.database.SingletonPostgresContainer
-import no.nav.amt.tiltak.test.database.data.TestData
 import no.nav.amt.tiltak.test.database.data.TestData.ARRANGOR_ANSATT_1
 import no.nav.amt.tiltak.test.database.data.TestData.ARRANGOR_ANSATT_2
 import no.nav.amt.tiltak.test.database.data.TestData.DELTAKER_1
@@ -49,7 +48,7 @@ class EndringsmeldingRepositoryTest : FunSpec({
 		DbTestDataUtils.cleanAndInitDatabaseWithTestData(dataSource)
 	}
 
-	test("insertOgInaktiverStartDato - Ingen tidligere endringsmeldinger - inserter melding med alle verdier") {
+	test("insertOgInaktiverStartDato - Ingen tidligere endringsmeldinger - inserter melding med startdato") {
 		val now = LocalDate.now()
 		val melding = repository.insertOgInaktiverStartDato(now, DELTAKER_1.id, ARRANGOR_ANSATT_1.id)
 
@@ -58,6 +57,7 @@ class EndringsmeldingRepositoryTest : FunSpec({
 		melding.aktiv shouldBe true
 		melding.opprettetAvArrangorAnsattId shouldBe ARRANGOR_ANSATT_1.id
 		melding.startDato shouldBe now
+		melding.sluttDato shouldBe null
 	}
 
 	test("insertOgInaktiverStartDato - Det finnes flere endringsmeldinger - inserter melding og inaktiverer den gamle") {
@@ -69,16 +69,50 @@ class EndringsmeldingRepositoryTest : FunSpec({
 		melding1.startDato shouldBe idag
 
 		val nyDato = LocalDate.now().minusDays(1)
-		val melding2 = repository.insertOgInaktiverStartDato(nyDato, DELTAKER_1.id, TestData.ARRANGOR_ANSATT_2.id)
+		val melding2 = repository.insertOgInaktiverStartDato(nyDato, DELTAKER_1.id, ARRANGOR_ANSATT_2.id)
 
 		melding2 shouldNotBe null
 		melding2.startDato shouldBe nyDato
 		melding2.aktiv shouldBe true
-		melding2.opprettetAvArrangorAnsattId shouldBe TestData.ARRANGOR_ANSATT_2.id
+		melding2.opprettetAvArrangorAnsattId shouldBe ARRANGOR_ANSATT_2.id
 
 		val forrigeMelding = repository.get(melding1.id)
 
 		melding1.copy(aktiv = false) shouldBe forrigeMelding
+	}
+
+	test("insertOgInaktiverSluttDato - Ingen tidligere endringsmeldinger - inserter melding med sluttdato") {
+		val now = LocalDate.now()
+		val melding = repository.insertOgInaktiverSluttDato(now, DELTAKER_1.id, ARRANGOR_ANSATT_1.id)
+
+		melding shouldNotBe null
+		melding.deltakerId shouldBe DELTAKER_1.id
+		melding.aktiv shouldBe true
+		melding.opprettetAvArrangorAnsattId shouldBe ARRANGOR_ANSATT_1.id
+		melding.startDato shouldBe null
+		melding.sluttDato shouldBe now
+	}
+
+	test("insertOgInaktiverSluttDato - Det finnes flere endringsmeldinger - inserter melding og inaktiverer ikke den med startdato") {
+		val idag = LocalDate.now()
+		val meldingMedStartDato = repository.insertOgInaktiverStartDato(idag, DELTAKER_1.id, ARRANGOR_ANSATT_1.id)
+
+		meldingMedStartDato.deltakerId shouldBe DELTAKER_1.id
+		meldingMedStartDato.aktiv shouldBe true
+		meldingMedStartDato.startDato shouldBe idag
+
+		val nyDato = LocalDate.now().plusDays(1)
+		val meldingMedSluttDato = repository.insertOgInaktiverSluttDato(nyDato, DELTAKER_1.id, ARRANGOR_ANSATT_2.id)
+
+		meldingMedSluttDato shouldNotBe null
+		meldingMedSluttDato.sluttDato shouldBe nyDato
+		meldingMedSluttDato.aktiv shouldBe true
+		meldingMedSluttDato.opprettetAvArrangorAnsattId shouldBe ARRANGOR_ANSATT_2.id
+
+		val forrigeMelding = repository.get(meldingMedStartDato.id)
+
+		forrigeMelding.aktiv shouldBe true
+		meldingMedStartDato shouldBe forrigeMelding
 	}
 
 	test("getByGjennomforing - en endringsmelding - henter endringsmelding") {

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingServiceImplTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingServiceImplTest.kt
@@ -43,7 +43,7 @@ class EndringsmeldingServiceImplTest {
 	}
 
 	@Test
-	fun `opprettMedStartDato - Inserter og inaktiverer forrige melding`() {
+	fun `opprettMedStartDato - Inserter og inaktiverer forrige melding med startdato`() {
 		val dato = LocalDate.now()
 
 		val melding1 = endringsmeldingService.opprettMedStartDato(DELTAKER_1.id, dato, ARRANGOR_ANSATT_1.id)
@@ -60,9 +60,28 @@ class EndringsmeldingServiceImplTest {
 	}
 
 	@Test
+	fun `opprettMedSluttDato - Inserter og inaktiverer forrige melding med sluttdato`() {
+		val dato = LocalDate.now()
+
+		val melding1 = endringsmeldingService.opprettMedSluttDato(DELTAKER_1.id, dato, ARRANGOR_ANSATT_1.id)
+		val melding2 = endringsmeldingService.opprettMedSluttDato(DELTAKER_1.id, dato.minusDays(2), ARRANGOR_ANSATT_1.id)
+
+		val result1 = repository.get(melding1.id)
+		val result2 = repository.get(melding2.id)
+
+		result1.aktiv shouldBe false
+		result1.sluttDato shouldBe dato
+
+		result2.aktiv shouldBe true
+		result2.sluttDato shouldBe dato.minusDays(2)
+	}
+
+
+
+	@Test
 	fun `hentEndringsmeldinger - en endringsmelding på gjennomføring - returnerer dto med alle verdier satt`() {
 		val nyStartDato = LocalDate.now().plusDays(3)
-		endringsmeldingService.opprettMedStartDato(DELTAKER_1.id, nyStartDato, ARRANGOR_ANSATT_1.id)
+		val opprettetMelding = endringsmeldingService.opprettMedStartDato(DELTAKER_1.id, nyStartDato, ARRANGOR_ANSATT_1.id)
 
 		val endringsmeldinger = endringsmeldingService.hentEndringsmeldingerForGjennomforing(DELTAKER_1.gjennomforingId)
 		val endringsmelding = endringsmeldinger.get(0)
@@ -71,12 +90,12 @@ class EndringsmeldingServiceImplTest {
 
 		endringsmelding.deltakerId shouldBe DELTAKER_1.id
 		endringsmelding.startDato shouldBe nyStartDato
-		endringsmelding.aktiv shouldBe true
+		endringsmelding.sluttDato shouldBe null
 		endringsmelding.opprettetAvArrangorAnsattId shouldBe ARRANGOR_ANSATT_1.id
 		endringsmelding.ferdiggjortAvNavAnsattId shouldBe null
 		endringsmelding.ferdiggjortTidspunkt shouldBe null
 		endringsmelding.aktiv shouldBe true
-		//endringsmelding.opprettet shouldBe null
+		endringsmelding.opprettet shouldBe opprettetMelding.opprettet
 	}
 
 	@Test


### PR DESCRIPTION
Det blir nå to forskjellige typer endringsmeldinger basert på hvilken av start- og sluttdato som er satt. Som kan bety at det kan være tilfeller hvor en deltaker har to aktive endringsmeldinger på en gang, en med startdato og en med sluttdato.