### PR TITLE
fikser så datostatusendring kan være null for noen deltakere

### DIFF
--- a/kafka/arena-acl-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena_acl_ingestor/dto/DeltakerPayload.kt
+++ b/kafka/arena-acl-ingestor/src/main/kotlin/no/nav/amt/tiltak/ingestors/arena_acl_ingestor/dto/DeltakerPayload.kt
@@ -15,7 +15,7 @@ data class DeltakerPayload(
 	val dagerPerUke: Int?,
 	val prosentDeltid: Float?,
 	val registrertDato: LocalDateTime,
-	val statusEndretDato: LocalDateTime,
+	val statusEndretDato: LocalDateTime?,
 	val innsokBegrunnelse: String?
 ) {
 	enum class Status {


### PR DESCRIPTION
Relast av andre tiltakstyper brakte denne til overflaten. Datostatusendring kan i noen tilfeller være null 