### PR TITLE
Avslutter deltakere som er på avsluttede gjennomføringer

### DIFF
--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Deltaker.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Deltaker.kt
@@ -33,22 +33,5 @@ data class Deltaker(
 	enum class StatusAarsak {
 		SYK, FATT_JOBB, TRENGER_ANNEN_STOTTE, FIKK_IKKE_PLASS, UTDANNING, FERDIG, AVLYST_KONTRAKT, IKKE_MOTT, FEILREGISTRERT, ANNET
 	}
-
-	fun utledStatus(): Status {
-		val now = LocalDate.now()
-
-		val sluttDato = sluttDato ?: LocalDate.now().plusYears(1000)
-
-		if(status.type == Status.VENTER_PA_OPPSTART && startDato == null)
-			return status.type
-
-		if(status.type == Status.VENTER_PA_OPPSTART && now.isAfter(startDato!!.minusDays(1)) && now.isBefore(sluttDato.plusDays(1)))
-			return Status.DELTAR
-
-		if(listOf(Status.DELTAR, Status.VENTER_PA_OPPSTART).contains(status.type) && now.isAfter(sluttDato))
-			return Status.HAR_SLUTTET
-
-		return status.type
-	}
 }
 


### PR DESCRIPTION
Fjerner kode som utleder om status skal endres, som gjør det samme som sql spørringen og håndterer at deltakere skal avsluttes når gjennomføringen avsluttes