### PR TITLE
Refaktorerer tilgangshåndtering for tiltaksarrangør ansatt for å støtte veileder rolle

### DIFF
--- a/arrangor/src/main/kotlin/no/nav/amt/tiltak/ansatt/ArrangorAnsattServiceImpl.kt
+++ b/arrangor/src/main/kotlin/no/nav/amt/tiltak/ansatt/ArrangorAnsattServiceImpl.kt
@@ -3,6 +3,7 @@ package no.nav.amt.tiltak.ansatt
 import no.nav.amt.tiltak.core.domain.arrangor.Ansatt
 import no.nav.amt.tiltak.core.domain.arrangor.TilknyttetArrangor
 import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle
+import no.nav.amt.tiltak.core.exceptions.UnauthorizedException
 import no.nav.amt.tiltak.core.port.ArrangorAnsattService
 import no.nav.amt.tiltak.core.port.ArrangorAnsattTilgangService
 import no.nav.amt.tiltak.core.port.ArrangorService
@@ -46,6 +47,11 @@ class ArrangorAnsattServiceImpl(
 		val arrangorer = hentTilknyttedeArrangorer(ansattDbo.id)
 
 		return ansattDbo.toAnsatt(arrangorer)
+	}
+
+	override fun getAnsattIdByPersonligIdent(personIdent: String) : UUID {
+		return arrangorAnsattRepository.getByPersonligIdent(personIdent)?.id
+			?: throw UnauthorizedException("Fant ikke ansatt")
 	}
 
 	override fun getKoordinatorerForGjennomforing(gjennomforingId: UUID): List<Ansatt> {
@@ -104,7 +110,7 @@ class ArrangorAnsattServiceImpl(
 				organisasjonsnummer = it.organisasjonsnummer,
 				overordnetEnhetOrganisasjonsnummer = it.overordnetEnhetOrganisasjonsnummer,
 				overordnetEnhetNavn = it.overordnetEnhetNavn,
-				roller = arrangorRoller.roller.map { it.name }
+				roller = arrangorRoller.roller
 			)
 		}
 	}

--- a/arrangor/src/test/kotlin/no/nav/amt/tiltak/ansatt/ArrangorAnsattRepositoryTest.kt
+++ b/arrangor/src/test/kotlin/no/nav/amt/tiltak/ansatt/ArrangorAnsattRepositoryTest.kt
@@ -85,7 +85,7 @@ class ArrangorAnsattRepositoryTest {
 			)
 		)
 
-		testRepository.insertArrangorAnsattGjennomforingTilgang(
+		testRepository.insertMineDeltakerlister(
 			ArrangorAnsattGjennomforingTilgangInput(
 				id = UUID.randomUUID(),
 				ansattId = ARRANGOR_ANSATT_2.id,

--- a/arrangor/src/test/kotlin/no/nav/amt/tiltak/veileder/ArrangorVeilederServiceImplTest.kt
+++ b/arrangor/src/test/kotlin/no/nav/amt/tiltak/veileder/ArrangorVeilederServiceImplTest.kt
@@ -5,7 +5,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.amt.tiltak.core.domain.arrangor.ArrangorVeilederInput
 import no.nav.amt.tiltak.core.port.ArrangorAnsattService
-import no.nav.amt.tiltak.core.port.ArrangorAnsattTilgangService
 import no.nav.amt.tiltak.core.port.DeltakerService
 import no.nav.amt.tiltak.core.port.GjennomforingService
 import no.nav.amt.tiltak.test.database.data.TestData.ARRANGOR_1
@@ -29,8 +28,6 @@ class ArrangorVeilederServiceImplTest {
 
 	lateinit var arrangorVeilederRepository: ArrangorVeilederRepository
 
-	lateinit var arrangorAnsattTilgangService: ArrangorAnsattTilgangService
-
 	lateinit var arrangorAnsattService: ArrangorAnsattService
 
 	lateinit var arrangorVeilederServiceImpl: ArrangorVeilederServiceImpl
@@ -44,7 +41,6 @@ class ArrangorVeilederServiceImplTest {
 	@BeforeEach
 	fun setup() {
 		arrangorVeilederRepository = mockk(relaxUnitFun = true)
-		arrangorAnsattTilgangService = mockk(relaxUnitFun = true)
 		arrangorAnsattService = mockk()
 		deltakerService = mockk()
 		gjennomforingService = mockk()
@@ -53,7 +49,6 @@ class ArrangorVeilederServiceImplTest {
 		arrangorVeilederServiceImpl = ArrangorVeilederServiceImpl(
 			arrangorAnsattService = arrangorAnsattService,
 			arrangorVeilederRepository = arrangorVeilederRepository,
-			arrangorAnsattTilgangService = arrangorAnsattTilgangService,
 			deltakerService = deltakerService,
 			gjennomforingService = gjennomforingService,
 			transactionTemplate = transactionTemplate,

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/AnsattController.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/AnsattController.kt
@@ -1,13 +1,9 @@
 package no.nav.amt.tiltak.bff.tiltaksarrangor
 
-import no.nav.amt.tiltak.ansatt.AnsattDto
-import no.nav.amt.tiltak.ansatt.toDto
 import no.nav.amt.tiltak.common.auth.AuthService
 import no.nav.amt.tiltak.common.auth.Issuer
-import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle
 import no.nav.amt.tiltak.core.port.ArrangorAnsattService
 import no.nav.amt.tiltak.core.port.ArrangorAnsattTilgangService
-import no.nav.amt.tiltak.core.port.PersonService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -19,41 +15,7 @@ class AnsattController(
 	private val authService: AuthService,
 	private val arrangorAnsattService: ArrangorAnsattService,
 	private val arrangorAnsattTilgangService: ArrangorAnsattTilgangService,
-	private val personService: PersonService
 ) {
-
-	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
-	@GetMapping("/meg")
-	fun getInnloggetAnsatt(): AnsattDto {
-		val personligIdent = authService.hentPersonligIdentTilInnloggetBruker()
-
-		arrangorAnsattTilgangService.synkroniserRettigheterMedAltinn(personligIdent)
-
-		val ansatt = arrangorAnsattService.getAnsattByPersonligIdent(personligIdent)
-
-		if (ansatt == null) {
-			return personService.hentPerson(personligIdent).let {
-				AnsattDto(
-					fornavn = it.fornavn,
-					etternavn = it.etternavn,
-					arrangorer = emptyList()
-				)
-			}
-		}
-
-		val arrangorerForAnsattMedKoordinatorRolle = ansatt.arrangorer
-			.filter { it.roller.contains(ArrangorAnsattRolle.KOORDINATOR) }
-
-		if (arrangorerForAnsattMedKoordinatorRolle.isNotEmpty()) {
-			arrangorAnsattService.setVellykketInnlogging(ansatt.id)
-		}
-
-		return AnsattDto(
-			fornavn = ansatt.fornavn,
-			etternavn = ansatt.etternavn,
-			arrangorer = arrangorerForAnsattMedKoordinatorRolle.map { it.toDto() }
-		)
-	}
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@GetMapping("/meg/roller")

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/AnsattController.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/AnsattController.kt
@@ -42,7 +42,7 @@ class AnsattController(
 		}
 
 		val arrangorerForAnsattMedKoordinatorRolle = ansatt.arrangorer
-			.filter { it.roller.contains(ArrangorAnsattRolle.KOORDINATOR.name) }
+			.filter { it.roller.contains(ArrangorAnsattRolle.KOORDINATOR) }
 
 		if (arrangorerForAnsattMedKoordinatorRolle.isNotEmpty()) {
 			arrangorAnsattService.setVellykketInnlogging(ansatt.id)
@@ -57,7 +57,7 @@ class AnsattController(
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@GetMapping("/meg/roller")
-	fun getMineRoller(): Set<String> {
+	fun getMineRoller(): List<String> {
 		val personligIdent = authService.hentPersonligIdentTilInnloggetBruker()
 		arrangorAnsattTilgangService.synkroniserRettigheterMedAltinn(personligIdent)
 
@@ -65,13 +65,12 @@ class AnsattController(
 
 		val roller = ansatt?.arrangorer
 			?.flatMap { it.roller }
-			?.toSet()
-			?: emptySet()
+			?: emptyList()
 
 		if (ansatt != null && roller.isNotEmpty()) {
 			arrangorAnsattService.setVellykketInnlogging(ansatt.id)
 		}
 
-		return roller
+		return roller.map { it.name }
 	}
 }

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/GjennomforingController.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/GjennomforingController.kt
@@ -1,22 +1,13 @@
 package no.nav.amt.tiltak.bff.tiltaksarrangor
 
-import no.nav.amt.tiltak.bff.tiltaksarrangor.dto.DeltakerlisteDto
-import no.nav.amt.tiltak.bff.tiltaksarrangor.dto.DeltakeroversiktDto
-import no.nav.amt.tiltak.bff.tiltaksarrangor.dto.GjennomforingDto
-import no.nav.amt.tiltak.bff.tiltaksarrangor.dto.KoordinatorDto
-import no.nav.amt.tiltak.bff.tiltaksarrangor.dto.KoordinatorInfoDto
-import no.nav.amt.tiltak.bff.tiltaksarrangor.dto.VeilederInfoDto
-import no.nav.amt.tiltak.bff.tiltaksarrangor.dto.toDeltakerlisteDto
-import no.nav.amt.tiltak.bff.tiltaksarrangor.dto.toDto
+import no.nav.amt.tiltak.bff.tiltaksarrangor.dto.*
 import no.nav.amt.tiltak.common.auth.AuthService
 import no.nav.amt.tiltak.common.auth.Issuer
 import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle.KOORDINATOR
+import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle.VEILEDER
 import no.nav.amt.tiltak.core.domain.tiltak.Gjennomforing
 import no.nav.amt.tiltak.core.exceptions.UnauthorizedException
-import no.nav.amt.tiltak.core.port.ArrangorAnsattService
-import no.nav.amt.tiltak.core.port.ArrangorAnsattTilgangService
-import no.nav.amt.tiltak.core.port.ArrangorVeilederService
-import no.nav.amt.tiltak.core.port.GjennomforingService
+import no.nav.amt.tiltak.core.port.*
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
@@ -31,19 +22,21 @@ class GjennomforingController(
 	private val authService: AuthService,
 	private val arrangorAnsattService: ArrangorAnsattService,
 	private val arrangorAnsattTilgangService: ArrangorAnsattTilgangService,
-	private val arrangorVeilederService: ArrangorVeilederService
+	private val arrangorVeilederService: ArrangorVeilederService,
+	private val mineDeltakerlisterService: MineDeltakerlisterService
 ) {
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@GetMapping("/gjennomforing")
-	fun hentGjennomforinger(): List<GjennomforingDto> {
+	fun hentDeltakerlisterLagtTil(): List<GjennomforingDto> {
 		val ansattPersonligIdent = authService.hentPersonligIdentTilInnloggetBruker()
-		arrangorAnsattTilgangService.shouldHaveRolle(ansattPersonligIdent, KOORDINATOR)
+		val ansatt = arrangorAnsattService.getAnsattByPersonligIdent(ansattPersonligIdent)
+			?: throw UnauthorizedException("Innlogget ansatt har ikke tilgang til gjennomføringer")
 
-		val gjennomforingIder = arrangorAnsattTilgangService
-			.hentGjennomforingIder(ansattPersonligIdent)
+		val deltakerlisterLagtTil = mineDeltakerlisterService.hentAlleForAnsatt(ansatt.id)
 
-		return gjennomforingService.getGjennomforinger(gjennomforingIder)
+		return gjennomforingService.getGjennomforinger(deltakerlisterLagtTil)
+			.filter { arrangorAnsattTilgangService.harRolleHosArrangor(ansatt.id, it.arrangor.id, KOORDINATOR) }
 			.filter(this::erSynligForArrangor)
 			.map { it.toDto() }
 	}
@@ -53,55 +46,73 @@ class GjennomforingController(
 	@GetMapping("/gjennomforing/tilgjengelig")
 	fun hentTilgjengeligeGjennomforinger(): List<GjennomforingDto> {
 		val ansattPersonligIdent = authService.hentPersonligIdentTilInnloggetBruker()
-		arrangorAnsattTilgangService.shouldHaveRolle(ansattPersonligIdent, KOORDINATOR)
+		val ansattId = arrangorAnsattService.getAnsattIdByPersonligIdent(ansattPersonligIdent)
 
-		val ansattId = arrangorAnsattTilgangService.hentAnsattId(ansattPersonligIdent)
+		arrangorAnsattTilgangService.verifiserHarRolleAnywhere(ansattId, KOORDINATOR)
 
-		return hentGjennomforingerSomKanLeggesTil(ansattId).map { it.toDto() }
+		return arrangorAnsattTilgangService.hentAnsattTilganger(ansattId)
+			.filter { it.roller.contains(KOORDINATOR) }
+			.map { gjennomforingService.getByArrangorId(it.arrangorId) }
+			.flatten()
+			.filter(this::erSynligForArrangor)
+			.map { it.toDto() }
 	}
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@PostMapping("/gjennomforing/{gjennomforingId}/tilgang")
 	fun opprettTilgangTilGjennomforing(@PathVariable("gjennomforingId") gjennomforingId: UUID) {
 		val ansattPersonligIdent = authService.hentPersonligIdentTilInnloggetBruker()
-		arrangorAnsattTilgangService.shouldHaveRolle(ansattPersonligIdent, KOORDINATOR)
+		val ansattId = arrangorAnsattService.getAnsattIdByPersonligIdent(ansattPersonligIdent)
+		val gjennomforing = gjennomforingService.getGjennomforing(gjennomforingId)
 
-		val ansattId = arrangorAnsattTilgangService.hentAnsattId(ansattPersonligIdent)
-
-		val gjennomforinger = hentGjennomforingerSomKanLeggesTil(ansattId)
-
-		if (!gjennomforinger.map { it.id }.contains(gjennomforingId)) {
+		if (!erSynligForArrangor(gjennomforing)) {
 			throw ResponseStatusException(HttpStatus.FORBIDDEN)
 		}
 
-		arrangorAnsattTilgangService.opprettTilgang(ansattPersonligIdent, gjennomforingId)
+		arrangorAnsattTilgangService.verifiserRolleHosArrangor(ansattId, gjennomforing.arrangor.id, KOORDINATOR)
+
+		mineDeltakerlisterService.leggTil(
+			UUID.randomUUID(),
+			ansattId,
+			gjennomforingId
+		)
 	}
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@DeleteMapping("/gjennomforing/{gjennomforingId}/tilgang")
 	fun fjernTilgangTilGjennomforing(@PathVariable("gjennomforingId") gjennomforingId: UUID) {
 		val ansattPersonligIdent = authService.hentPersonligIdentTilInnloggetBruker()
-		arrangorAnsattTilgangService.shouldHaveRolle(ansattPersonligIdent, KOORDINATOR)
+		val ansattId = arrangorAnsattService.getAnsattIdByPersonligIdent(ansattPersonligIdent)
+		val arrangorId = gjennomforingService.getArrangorId(gjennomforingId)
 
-		arrangorAnsattTilgangService.fjernTilgang(ansattPersonligIdent, gjennomforingId)
+		arrangorAnsattTilgangService.verifiserRolleHosArrangor(ansattId, arrangorId, KOORDINATOR)
+		mineDeltakerlisterService.fjern(ansattId, gjennomforingId)
 	}
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@GetMapping("/gjennomforing/{gjennomforingId}")
 	fun hentGjennomforing(@PathVariable("gjennomforingId") gjennomforingId: UUID): GjennomforingDto {
 		val ansattPersonligIdent = authService.hentPersonligIdentTilInnloggetBruker()
+		val ansattId = arrangorAnsattService.getAnsattIdByPersonligIdent(ansattPersonligIdent)
+		val harLagtTilListe = mineDeltakerlisterService.harLagtTilDeltakerliste(ansattId, gjennomforingId)
+		val gjennomforing = gjennomforingService.getGjennomforing(gjennomforingId)
 
-		val gjennomforing = gjennomforingService.getGjennomforing(gjennomforingId).toDto()
-		arrangorAnsattTilgangService.verifiserTilgangTilGjennomforing(ansattPersonligIdent, gjennomforingId, KOORDINATOR)
-		return gjennomforing
+		if (!harLagtTilListe){
+			throw ResponseStatusException(HttpStatus.FORBIDDEN, "Ansatt $ansattId kan ikke hente deltaker før den er lagt til")
+		}
+
+		arrangorAnsattTilgangService.verifiserRolleHosArrangor(ansattId, gjennomforing.arrangor.id, KOORDINATOR)
+
+		return gjennomforing.toDto()
 	}
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
 	@GetMapping("/gjennomforing/{gjennomforingId}/koordinatorer")
 	fun hentKoordinatorerPaGjennomforing(@PathVariable("gjennomforingId") gjennomforingId: UUID): List<KoordinatorDto> {
 		val ansattPersonligIdent = authService.hentPersonligIdentTilInnloggetBruker()
+		val ansattId = arrangorAnsattService.getAnsattIdByPersonligIdent(ansattPersonligIdent)
 
-		arrangorAnsattTilgangService.verifiserTilgangTilGjennomforing(ansattPersonligIdent, gjennomforingId, KOORDINATOR)
+		arrangorAnsattTilgangService.verifiserTilgangTilGjennomforing(ansattId, gjennomforingId)
 
 		return arrangorAnsattService.getKoordinatorerForGjennomforing(gjennomforingId)
 			.map {
@@ -120,20 +131,21 @@ class GjennomforingController(
 		val ansatt = arrangorAnsattService.getAnsattByPersonligIdent(ansattPersonligIdent)
 			?: throw UnauthorizedException("Arrangor-ansatt finnes ikke")
 
+
 		val roller = ansatt.arrangorer
 			.flatMap { it.roller }
-			.toSet()
+
 		if (roller.isEmpty()) {
 			throw ResponseStatusException(HttpStatus.FORBIDDEN, "Ansatt ${ansatt.id} er ikke veileder eller koordinator")
 		}
 
-		val koordinatorInfo = if (roller.contains("KOORDINATOR")) {
+		val koordinatorInfo = if (roller.contains(KOORDINATOR)) {
 			KoordinatorInfoDto(getDeltakerlister(ansattPersonligIdent))
 		} else {
 			null
 		}
 
-		val veilederInfo = if (roller.contains("VEILEDER")) {
+		val veilederInfo = if (roller.contains(VEILEDER)) {
 			val veilederrelasjoner = arrangorVeilederService.hentDeltakereForVeileder(ansatt.id)
 			VeilederInfoDto(
 				veilederFor = veilederrelasjoner.count { !it.erMedveileder },
@@ -150,19 +162,12 @@ class GjennomforingController(
 	}
 
 	private fun getDeltakerlister(ansattPersonligIdent: String): List<DeltakerlisteDto> {
-		val gjennomforingIder = arrangorAnsattTilgangService.hentGjennomforingIder(ansattPersonligIdent)
+		val ansattId = arrangorAnsattService.getAnsattIdByPersonligIdent(ansattPersonligIdent)
+		val gjennomforingIder = mineDeltakerlisterService.hentAlleForAnsatt(ansattId)
 
 		return gjennomforingService.getGjennomforinger(gjennomforingIder)
 			.filter { erSynligForArrangor(it) }
 			.map { it.toDeltakerlisteDto() }
-	}
-
-	private fun hentGjennomforingerSomKanLeggesTil(ansattId: UUID): List<Gjennomforing> {
-		return arrangorAnsattTilgangService.hentAnsattTilganger(ansattId)
-			.filter { it.roller.contains(KOORDINATOR) }
-			.map { gjennomforingService.getByArrangorId(it.arrangorId) }
-			.flatten()
-			.filter(this::erSynligForArrangor)
 	}
 
 	private fun erSynligForArrangor(gjennomforing: Gjennomforing): Boolean {

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/GjennomforingController.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/GjennomforingController.kt
@@ -33,7 +33,7 @@ class GjennomforingController(
 		val ansatt = arrangorAnsattService.getAnsattByPersonligIdent(ansattPersonligIdent)
 			?: throw UnauthorizedException("Innlogget ansatt har ikke tilgang til gjennomføringer")
 
-		val deltakerlisterLagtTil = mineDeltakerlisterService.hentAlleForAnsatt(ansatt.id)
+		val deltakerlisterLagtTil = mineDeltakerlisterService.hent(ansatt.id)
 
 		return gjennomforingService.getGjennomforinger(deltakerlisterLagtTil)
 			.filter { arrangorAnsattTilgangService.harRolleHosArrangor(ansatt.id, it.arrangor.id, KOORDINATOR) }
@@ -94,7 +94,7 @@ class GjennomforingController(
 	fun hentGjennomforing(@PathVariable("gjennomforingId") gjennomforingId: UUID): GjennomforingDto {
 		val ansattPersonligIdent = authService.hentPersonligIdentTilInnloggetBruker()
 		val ansattId = arrangorAnsattService.getAnsattIdByPersonligIdent(ansattPersonligIdent)
-		val harLagtTilListe = mineDeltakerlisterService.harLagtTilDeltakerliste(ansattId, gjennomforingId)
+		val harLagtTilListe = mineDeltakerlisterService.erLagtTil(ansattId, gjennomforingId)
 		val gjennomforing = gjennomforingService.getGjennomforing(gjennomforingId)
 
 		if (!harLagtTilListe){
@@ -163,7 +163,7 @@ class GjennomforingController(
 
 	private fun getDeltakerlister(ansattPersonligIdent: String): List<DeltakerlisteDto> {
 		val ansattId = arrangorAnsattService.getAnsattIdByPersonligIdent(ansattPersonligIdent)
-		val gjennomforingIder = mineDeltakerlisterService.hentAlleForAnsatt(ansattId)
+		val gjennomforingIder = mineDeltakerlisterService.hent(ansattId)
 
 		return gjennomforingService.getGjennomforinger(gjennomforingIder)
 			.filter { erSynligForArrangor(it) }

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/dto/AnsattDto.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/dto/AnsattDto.kt
@@ -34,6 +34,6 @@ fun TilknyttetArrangor.toDto(): TilknyttetArrangorDto {
 		organisasjonsnummer = this.organisasjonsnummer,
 		overordnetEnhetOrganisasjonsnummer = this.overordnetEnhetOrganisasjonsnummer,
 		overordnetEnhetNavn = this.overordnetEnhetNavn,
-		roller = this.roller
+		roller = this.roller.map { it.name }
 	)
 }

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/arrangor/TilknyttetArrangor.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/arrangor/TilknyttetArrangor.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.tiltak.core.domain.arrangor
 
+import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle
 import java.util.*
 
 data class TilknyttetArrangor(
@@ -8,5 +9,5 @@ data class TilknyttetArrangor(
 	val organisasjonsnummer: String,
 	val overordnetEnhetOrganisasjonsnummer: String?,
 	val overordnetEnhetNavn: String?,
-	val roller: List<String>
+	val roller: List<ArrangorAnsattRolle>
 )

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/ArrangorAnsattService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/ArrangorAnsattService.kt
@@ -21,4 +21,5 @@ interface ArrangorAnsattService {
 	fun setTilgangerSistSynkronisert(ansattId: UUID, sistOppdatert: LocalDateTime)
 	fun getAnsatteSistSynkronisertEldreEnn(eldreEnn: LocalDateTime, maksAntall: Int): List<Ansatt>
 	fun setVellykketInnlogging(ansattId: UUID)
+	fun getAnsattIdByPersonligIdent(personIdent: String): UUID
 }

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/ArrangorAnsattTilgangService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/ArrangorAnsattTilgangService.kt
@@ -6,47 +6,17 @@ import java.util.*
 
 interface ArrangorAnsattTilgangService {
 
-	fun verifiserTilgangTilGjennomforing(
-		ansattPersonligIdent: String,
-		gjennomforingId: UUID,
-		rolle: ArrangorAnsattRolle
-	)
+	fun verifiserTilgangTilGjennomforing(ansattId: UUID, gjennomforingId: UUID)
 
-	fun verifiserTilgangTilGjennomforing(
-		ansattPersonligIdent: String,
-		gjennomforingId: UUID,
-		roller: List<ArrangorAnsattRolle>
-	)
-
-	fun verifiserTilgangTilGjennomforing(ansattId: UUID, gjennomforingId: UUID, roller: ArrangorAnsattRolle)
-
-	fun verifiserTilgangTilGjennomforing(ansattId: UUID, gjennomforingId: UUID, roller: List<ArrangorAnsattRolle>)
-
-	fun verifiserTilgangTilArrangor(ansattPersonligIdent: String, arrangorId: UUID, rolle: ArrangorAnsattRolle)
-
-	fun verifiserTilgangTilArrangor(ansattId: UUID, arrangorId: UUID, rolle: ArrangorAnsattRolle)
-
-	fun verifiserTilgangTilDeltaker(ansattPersonligIdent: String, deltakerId: UUID, rolle: ArrangorAnsattRolle)
-
-	fun verifiserTilgangTilDeltaker(ansattPersonligIdent: String, deltakerId: UUID, roller: List<ArrangorAnsattRolle>)
-
-	fun verifiserTilgangTilDeltaker(ansattId: UUID, deltakerId: UUID, rolle: ArrangorAnsattRolle)
-
-	fun verifiserTilgangTilDeltaker(ansattId: UUID, deltakerId: UUID, roller: List<ArrangorAnsattRolle>)
+	fun verifiserTilgangTilDeltaker(ansattId: UUID, deltakerId: UUID)
 
 	fun hentAnsattTilganger(ansattId: UUID): List<ArrangorAnsattRoller>
 
-	fun hentRollerForAnsattTilknyttetDeltaker(ansattId: UUID, deltakerId: UUID): List<ArrangorAnsattRolle>
-
-	fun hentGjennomforingIder(ansattPersonligIdent: String): List<UUID>
-
-	fun hentAnsattId(ansattPersonligIdent: String): UUID
-
-	fun opprettTilgang(ansattPersonligIdent: String, gjennomforingId: UUID)
-
-	fun fjernTilgang(ansattPersonligIdent: String, gjennomforingId: UUID)
-
 	fun synkroniserRettigheterMedAltinn(ansattPersonligIdent: String)
 
-	fun shouldHaveRolle(personligIdent: String, rolle: ArrangorAnsattRolle)
+	fun verifiserRolleHosArrangor(ansattId: UUID, arrangorId: UUID, rolle: ArrangorAnsattRolle)
+
+	fun harRolleHosArrangor(ansattId: UUID, arrangorId: UUID, rolle: ArrangorAnsattRolle): Boolean
+
+	fun verifiserHarRolleAnywhere(ansattId: UUID, rolle: ArrangorAnsattRolle)
 }

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/GjennomforingService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/GjennomforingService.kt
@@ -18,4 +18,5 @@ interface GjennomforingService {
 
 	fun slettGjennomforing(gjennomforingId: UUID)
 
+	fun getArrangorId(gjennomforingId: UUID): UUID
 }

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/MineDeltakerlisterService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/MineDeltakerlisterService.kt
@@ -6,7 +6,7 @@ interface MineDeltakerlisterService {
 
 	fun leggTil(id: UUID, arrangorAnsattId: UUID, gjennomforingId: UUID)
 	fun fjern(arrangorAnsattId: UUID, gjennomforingId: UUID)
-	fun fjernGjennomforinger(arrangorAnsattId: UUID, arrangorId: UUID)
-	fun hentAlleForAnsatt(ansattId: UUID): List<UUID>
-	fun harLagtTilDeltakerliste(ansattId: UUID, gjennomforingId: UUID): Boolean
+	fun fjernAlleHosArrangor(arrangorAnsattId: UUID, arrangorId: UUID)
+	fun hent(ansattId: UUID): List<UUID>
+	fun erLagtTil(ansattId: UUID, gjennomforingId: UUID): Boolean
 }

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/MineDeltakerlisterService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/MineDeltakerlisterService.kt
@@ -1,0 +1,12 @@
+package no.nav.amt.tiltak.core.port
+
+import java.util.*
+
+interface MineDeltakerlisterService {
+
+	fun leggTil(id: UUID, arrangorAnsattId: UUID, gjennomforingId: UUID)
+	fun fjern(arrangorAnsattId: UUID, gjennomforingId: UUID)
+	fun fjernGjennomforinger(arrangorAnsattId: UUID, arrangorId: UUID)
+	fun hentAlleForAnsatt(ansattId: UUID): List<UUID>
+	fun harLagtTilDeltakerliste(ansattId: UUID, gjennomforingId: UUID): Boolean
+}

--- a/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/AnsattControllerIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/AnsattControllerIntegrationTest.kt
@@ -1,31 +1,19 @@
 package no.nav.amt.tiltak.test.integration.tiltaksarrangor
 
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
-import no.nav.amt.tiltak.ansatt.AnsattDto
-import no.nav.amt.tiltak.ansatt.ArrangorAnsattRepository
 import no.nav.amt.tiltak.common.json.JsonUtils
-import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle
 import no.nav.amt.tiltak.test.database.DbTestDataUtils
-import no.nav.amt.tiltak.test.database.data.TestData
 import no.nav.amt.tiltak.test.database.data.TestData.ARRANGOR_1
 import no.nav.amt.tiltak.test.database.data.TestData.ARRANGOR_2
-import no.nav.amt.tiltak.test.database.data.TestData.ARRANGOR_ANSATT_1
 import no.nav.amt.tiltak.test.integration.IntegrationTestBase
 import no.nav.amt.tiltak.test.integration.mocks.MockPdlBruker
 import no.nav.amt.tiltak.test.integration.test_utils.ControllerTestUtils.testTiltaksarrangorAutentisering
 import okhttp3.Request
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 import java.util.*
 
 class AnsattControllerIntegrationTest : IntegrationTestBase() {
-
-	@Autowired
-	lateinit var arrangorAnsattRepository: ArrangorAnsattRepository
 
 	@BeforeEach
 	internal fun setUp() {
@@ -33,88 +21,13 @@ class AnsattControllerIntegrationTest : IntegrationTestBase() {
 		resetMockServersAndAddDefaultData()
 	}
 
-
 	@Test
 	internal fun `skal teste token autentisering`() {
 
 		val requestBuilders = listOf(
-			Request.Builder().get().url("${serverUrl()}/api/tiltaksarrangor/ansatt/meg"),
+			Request.Builder().get().url("${serverUrl()}/api/tiltaksarrangor/ansatt/meg/roller"),
 		)
 		testTiltaksarrangorAutentisering(requestBuilders, client, mockOAuthServer)
-	}
-
-	@Test
-	fun `getInnloggetAnsatt() should return 200 when authenticated and be logged in DB`() {
-		val response = sendRequest(
-			method = "GET",
-			url = "/api/tiltaksarrangor/ansatt/meg",
-			headers = mapOf("Authorization" to "Bearer ${mockOAuthServer.issueTokenXToken(ARRANGOR_ANSATT_1.personligIdent)}")
-		)
-
-		val arrangorAnsatt = arrangorAnsattRepository.get(ARRANGOR_ANSATT_1.id)
-		arrangorAnsatt shouldNotBe null
-		arrangorAnsatt!!.sistVelykkedeInnlogging.truncatedTo(ChronoUnit.HOURS) shouldBe LocalDateTime.now()
-			.truncatedTo(ChronoUnit.HOURS)
-
-
-		response.code shouldBe 200
-	}
-
-	@Test
-	fun `getInnloggetAnsatt() should return 200 and no arrangorer when only VEILEDER`() {
-		val response = sendRequest(
-			method = "GET",
-			url = "/api/tiltaksarrangor/ansatt/meg",
-			headers = mapOf("Authorization" to "Bearer ${mockOAuthServer.issueTokenXToken(TestData.ARRANGOR_ANSATT_2.personligIdent)}")
-		)
-
-		response.code shouldBe 200
-		val responseBody: AnsattDto? = response.body?.string()?.let { JsonUtils.fromJsonString(it) }
-
-		responseBody shouldNotBe null
-		responseBody!!.arrangorer.isEmpty() shouldBe true
-	}
-
-	@Test
-	fun `getInnloggetAnsatt() should return 200 and only arrangorer with KOORDINATOR roller`() {
-		val response = sendRequest(
-			method = "GET",
-			url = "/api/tiltaksarrangor/ansatt/meg",
-			headers = mapOf("Authorization" to "Bearer ${mockOAuthServer.issueTokenXToken(TestData.ARRANGOR_ANSATT_1.personligIdent)}")
-		)
-
-		response.code shouldBe 200
-		val responseBody: AnsattDto? = response.body?.string()?.let { JsonUtils.fromJsonString(it) }
-
-		responseBody shouldNotBe null
-		responseBody!!.arrangorer.none { it.roller.contains(ArrangorAnsattRolle.VEILEDER.name) } shouldBe true
-	}
-
-	@Test
-	fun `getInnloggetAnsatt() should return 200 when ansatt is not previously stored`() {
-		val ident = "012345678912"
-
-		mockAmtAltinnAclHttpServer.addRoller(
-			norskIdent = ident,
-			orgNr = ARRANGOR_1.organisasjonsnummer,
-			roller = listOf("KOORDINATOR")
-		)
-		mockPdlHttpServer.mockHentBruker(ident, MockPdlBruker("Integrasjon", "Test"))
-
-		val response = sendRequest(
-			method = "GET",
-			url = "/api/tiltaksarrangor/ansatt/meg",
-			headers = mapOf("Authorization" to "Bearer ${mockOAuthServer.issueTokenXToken(ident)}")
-		)
-
-		val expectedJson = """
-			{"fornavn":"Integrasjon","etternavn":"Test","arrangorer":[{"id":"8a37bce6-3bc1-11ec-8d3d-0242ac130003","navn":"Tiltaksarrangør 1","organisasjonsnummer":"111111111","overordnetEnhetOrganisasjonsnummer":"911111111","overordnetEnhetNavn":"Org Tiltaksarrangør 1","roller":["KOORDINATOR"]}]}
-		""".trimIndent()
-
-		response.code shouldBe 200
-
-		response.body?.string() shouldBe expectedJson
-
 	}
 
 	@Test

--- a/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/DeltakerControllerIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/DeltakerControllerIntegrationTest.kt
@@ -21,7 +21,7 @@ import no.nav.amt.tiltak.test.database.data.TestData.ENDRINGSMELDING_1_DELTAKER_
 import no.nav.amt.tiltak.test.database.data.TestData.ENDRINGSMELDING_1_DELTAKER_2
 import no.nav.amt.tiltak.test.database.data.TestData.GJENNOMFORING_1
 import no.nav.amt.tiltak.test.database.data.TestData.GJENNOMFORING_2
-import no.nav.amt.tiltak.test.database.data.inputs.ArrangorAnsattGjennomforingTilgangInput
+import no.nav.amt.tiltak.test.database.data.inputs.ArrangorVeilederDboInput
 import no.nav.amt.tiltak.test.database.data.inputs.DeltakerStatusInput
 import no.nav.amt.tiltak.test.integration.IntegrationTestBase
 import no.nav.amt.tiltak.test.integration.test_utils.ControllerTestUtils.testTiltaksarrangorAutentisering
@@ -586,18 +586,20 @@ class DeltakerControllerIntegrationTest : IntegrationTestBase() {
 	}
 
 	@Test
-	fun `skjulDeltakerForTiltaksarrangor() - VEILEDER - skal skjule deltaker`() {
+	fun `skjulDeltakerForTiltaksarrangor() - VEILEDER - skal kunne skjule deltaker`() {
 		val deltakerId = UUID.randomUUID()
 		testDataRepository.insertDeltaker(DELTAKER_1.copy(id = deltakerId))
 		testDataRepository.insertDeltakerStatus(DELTAKER_1_STATUS_1.copy(id = UUID.randomUUID(), deltakerId = deltakerId, status = "IKKE_AKTUELL"))
 
-		testDataRepository.insertArrangorAnsattGjennomforingTilgang(ArrangorAnsattGjennomforingTilgangInput(
-			id = UUID.randomUUID(),
-			ARRANGOR_ANSATT_2.id,
-			DELTAKER_1.gjennomforingId,
-			ZonedDateTime.now().minusDays(1),
-			ZonedDateTime.now().plusDays(1)
-		))
+		testDataRepository.insertArrangorVeileder(
+			ArrangorVeilederDboInput(
+				id = UUID.randomUUID(),
+				ansattId = ARRANGOR_ANSATT_2.id,
+				deltakerId = deltakerId,
+				erMedveileder = false,
+				gyldigFra = ZonedDateTime.now().minusDays(1),
+				gyldigTil = ZonedDateTime.now().plusDays(1)
+			))
 
 		val response = sendRequest(
 			method = "PATCH",

--- a/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/GjennomforingControllerIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/GjennomforingControllerIntegrationTest.kt
@@ -47,7 +47,7 @@ class GjennomforingControllerIntegrationTest : IntegrationTestBase() {
 	@Test
 	fun `hentGjennomforinger() skal returnere 403 om Ansatt kun er veileder`() {
 
-		testDataRepository.insertArrangorAnsattGjennomforingTilgang(
+		testDataRepository.insertMineDeltakerlister(
 			ArrangorAnsattGjennomforingTilgangInput(
 				id = UUID.randomUUID(),
 				ansattId = ARRANGOR_ANSATT_2.id,
@@ -126,7 +126,7 @@ class GjennomforingControllerIntegrationTest : IntegrationTestBase() {
 			)
 		)
 
-		testDataRepository.insertArrangorAnsattGjennomforingTilgang(
+		testDataRepository.insertMineDeltakerlister(
 			ArrangorAnsattGjennomforingTilgangInput(
 				id = UUID.randomUUID(),
 				ansattId = ARRANGOR_ANSATT_1.id,
@@ -136,7 +136,7 @@ class GjennomforingControllerIntegrationTest : IntegrationTestBase() {
 			)
 		)
 
-		testDataRepository.insertArrangorAnsattGjennomforingTilgang(
+		testDataRepository.insertMineDeltakerlister(
 			ArrangorAnsattGjennomforingTilgangInput(
 				id = UUID.randomUUID(),
 				ansattId = ARRANGOR_ANSATT_1.id,

--- a/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/VeilederControllerIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/VeilederControllerIntegrationTest.kt
@@ -307,19 +307,6 @@ class VeilederControllerIntegrationTest : IntegrationTestBase() {
 	}
 
 	@Test
-	internal fun `tildelVeiledereForDeltaker - request med for mange hovedveiledere - skal kaste 400`() {
-		val response = sendRequest(
-			method = "PATCH",
-			url = "/api/tiltaksarrangor/veiledere?deltakerId=${DELTAKER_1.id}",
-			headers = lagAnsatt1Header(),
-			body = lagOpprettVeiledereRequestBody(
-				veiledere = listOf(Pair(ARRANGOR_ANSATT_2.id, false), Pair(ARRANGOR_ANSATT_1.id, false)),
-			),
-		)
-		response.code shouldBe 400
-	}
-
-	@Test
 	internal fun `tildelVeiledereForDeltaker - request med for mange medveiledere - skal kaste 400`() {
 		val response = sendRequest(
 			method = "PATCH",
@@ -491,16 +478,16 @@ class VeilederControllerIntegrationTest : IntegrationTestBase() {
 
 	@Test
 	internal fun `hentDeltakerliste - er veileder - henter deltakerliste`() {
-		testDataRepository.insertArrangorVeileder(ARRANGOR_ANSATT_1_VEILEDER_1)
+		testDataRepository.insertArrangorVeileder(ARRANGOR_ANSATT_2_VEILEDER_1)
 		val response = sendRequest(
 			method = "GET",
 			url = "/api/tiltaksarrangor/veileder/deltakerliste",
-			headers = lagAnsatt1Header(),
+			headers = lagAnsatt2Header(),
 		)
 
 		response.code shouldBe 200
 		response.body!!.string() shouldBe """
-			[{"id":"dc600c70-124f-4fe7-a687-b58439beb214","fornavn":"Bruker 1 fornavn","mellomnavn":null,"etternavn":"Bruker 1 etternavn","fodselsnummer":"12345678910","startDato":"2022-02-13","sluttDato":"2030-02-14","status":{"type":"DELTAR","endretDato":"2022-02-13T00:00:00"},"deltakerliste":{"id":"b3420940-5479-48c8-b2fa-3751c7a33aa2","navn":"Tiltaksgjennomforing1","type":"Tiltak1"},"erMedveilederFor":false}]
+			[{"id":"dc600c70-124f-4fe7-a687-b58439beb214","fornavn":"Bruker 1 fornavn","mellomnavn":null,"etternavn":"Bruker 1 etternavn","fodselsnummer":"12345678910","startDato":"2022-02-13","sluttDato":"2030-02-14","status":{"type":"DELTAR","endretDato":"2022-02-13T00:00:00"},"deltakerliste":{"id":"b3420940-5479-48c8-b2fa-3751c7a33aa2","navn":"Tiltaksgjennomforing1","type":"Tiltak1"},"erMedveilederFor":true}]
 		""".trimIndent()
 	}
 

--- a/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/TestDataRepository.kt
+++ b/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/TestDataRepository.kt
@@ -32,7 +32,7 @@ class TestDataRepository(
 		)
 	}
 
-	fun insertArrangorAnsattGjennomforingTilgang(cmd: ArrangorAnsattGjennomforingTilgangInput) {
+	fun insertMineDeltakerlister(cmd: ArrangorAnsattGjennomforingTilgangInput) {
 		val sql = """
 			INSERT INTO arrangor_ansatt_gjennomforing_tilgang(id, ansatt_id, gjennomforing_id, gyldig_fra, gyldig_til)
 			VALUES(:id, :ansatt_id, :gjennomforing_id, :gyldig_fra, :gyldig_til)

--- a/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/TestDataSeeder.kt
+++ b/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/TestDataSeeder.kt
@@ -53,7 +53,7 @@ object TestDataSeeder {
 		repository.insertGjennomforing(GJENNOMFORING_1)
 		repository.insertGjennomforing(GJENNOMFORING_2)
 
-		repository.insertArrangorAnsattGjennomforingTilgang(GJENNOMFORING_TILGANG_1)
+		repository.insertMineDeltakerlister(GJENNOMFORING_TILGANG_1)
 
 		repository.insertNavAnsatt(NAV_ANSATT_1)
 		repository.insertNavAnsatt(NAV_ANSATT_2)
@@ -87,7 +87,7 @@ object TestDataSeeder {
 		repository.insertTiltak(TILTAK_1)
 		repository.insertGjennomforing(GJENNOMFORING_1)
 
-		repository.insertArrangorAnsattGjennomforingTilgang(GJENNOMFORING_TILGANG_1)
+		repository.insertMineDeltakerlister(GJENNOMFORING_TILGANG_1)
 
 		repository.insertNavAnsatt(NAV_ANSATT_1)
 

--- a/tilgangskontroll-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattTilgangServiceImpl.kt
+++ b/tilgangskontroll-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattTilgangServiceImpl.kt
@@ -28,9 +28,9 @@ open class ArrangorAnsattTilgangServiceImpl(
 	private val log = LoggerFactory.getLogger(javaClass)
 
 	override fun verifiserTilgangTilGjennomforing(ansattId: UUID, gjennomforingId: UUID) {
-		val gjennomforing = gjennomforingService.getGjennomforing(gjennomforingId)
+		val arrangorId = gjennomforingService.getArrangorId(gjennomforingId)
 
-		if (!harKoordinatorTilgang(ansattId, gjennomforingId, gjennomforing.arrangor.id)){
+		if (!harKoordinatorTilgang(ansattId, gjennomforingId, arrangorId)){
 			secureLog.warn("Ansatt med id=$ansattId har ikke tilgang til gjennomføring med id=$gjennomforingId")
 			throw ResponseStatusException(HttpStatus.FORBIDDEN, "Ansatt har ikke tilgang til gjennomforing")
 		}
@@ -40,10 +40,10 @@ open class ArrangorAnsattTilgangServiceImpl(
 		val deltaker = deltakerService.hentDeltaker(deltakerId)
 			?: throw NoSuchElementException("Fant ikke deltaker med id $deltakerId")
 
-		val gjennomforing = gjennomforingService.getGjennomforing(deltaker.gjennomforingId)
+		val arrangorId = gjennomforingService.getArrangorId(deltaker.gjennomforingId)
 
-		if(!harKoordinatorTilgang(ansattId, deltaker.gjennomforingId, gjennomforing.arrangor.id)
-			&& !harVeilederTilgang(ansattId, deltakerId, gjennomforing.arrangor.id)) {
+		if(!harKoordinatorTilgang(ansattId, deltaker.gjennomforingId, arrangorId)
+			&& !harVeilederTilgang(ansattId, deltakerId, arrangorId)) {
 			throw ResponseStatusException(HttpStatus.FORBIDDEN, "Arrangør ansatt med id:$ansattId har ikke tilgang til deltaker med id $deltakerId")
 		}
 

--- a/tilgangskontroll-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/MineDeltakerlisterRepository.kt
+++ b/tilgangskontroll-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/MineDeltakerlisterRepository.kt
@@ -11,7 +11,7 @@ import java.time.ZonedDateTime
 import java.util.*
 
 @Component
-open class ArrangorAnsattGjennomforingTilgangRepository(
+open class MineDeltakerlisterRepository(
 	private val template: NamedParameterJdbcTemplate
 ) {
 
@@ -37,7 +37,7 @@ open class ArrangorAnsattGjennomforingTilgangRepository(
 			?: throw NoSuchElementException("Fant ikke arrangor_ansatt_gjennomforing_tilgang med id $id")
 	}
 
-	internal fun opprettTilgang(
+	internal fun leggTil(
 		id: UUID,
 		arrangorAnsattId: UUID,
 		gjennomforingId: UUID,
@@ -60,7 +60,7 @@ open class ArrangorAnsattGjennomforingTilgangRepository(
 		template.update(sql, parameters)
 	}
 
-	internal fun fjernTilgang(arrangorAnsattId: UUID, gjennomforingId: UUID) {
+	internal fun fjern(arrangorAnsattId: UUID, gjennomforingId: UUID) {
 		val sql = """
 			UPDATE arrangor_ansatt_gjennomforing_tilgang
 			SET gyldig_til = current_timestamp
@@ -75,7 +75,7 @@ open class ArrangorAnsattGjennomforingTilgangRepository(
 		template.update(sql, parameters)
 	}
 
-	internal fun hentAktiveGjennomforingTilgangerForAnsatt(ansattId: UUID): List<ArrangorAnsattGjennomforingTilgangDbo> {
+	internal fun hent(ansattId: UUID): List<ArrangorAnsattGjennomforingTilgangDbo> {
 		val sql = """
 			SELECT * FROM arrangor_ansatt_gjennomforing_tilgang
 				WHERE ansatt_id = :ansattId AND gyldig_fra < current_timestamp AND gyldig_til > current_timestamp
@@ -86,7 +86,7 @@ open class ArrangorAnsattGjennomforingTilgangRepository(
 		return template.query(sql, parameters, rowMapper)
 	}
 
-	fun getAntallGjennomforingerPerAnsatt(): Map<UUID, Int> {
+	fun hentAntallPerAnsatt(): Map<UUID, Int> {
 
 		@Language("PostgreSQL")
 		val sql = """

--- a/tilgangskontroll-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/MineDeltakerlisterServiceImpl.kt
+++ b/tilgangskontroll-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/MineDeltakerlisterServiceImpl.kt
@@ -1,22 +1,23 @@
 package no.nav.amt.tiltak.tilgangskontroll_tiltaksarrangor.tilgang
 
 import no.nav.amt.tiltak.core.port.GjennomforingService
+import no.nav.amt.tiltak.core.port.MineDeltakerlisterService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.ZonedDateTime
 import java.util.*
 
 @Service
-open class ArrangorAnsattGjennomforingTilgangService(
-	private val arrangorAnsattGjennomforingTilgangRepository: ArrangorAnsattGjennomforingTilgangRepository,
+open class MineDeltakerlisterServiceImpl(
+	private val mineDeltakerlisterRepository: MineDeltakerlisterRepository,
 	private val gjennomforingService: GjennomforingService,
 	private val transactionTemplate: TransactionTemplate
-) {
+): MineDeltakerlisterService {
 
 	private val defaultGyldigTil = ZonedDateTime.parse("3000-01-01T00:00:00.00000+00:00")
 
-	open fun opprettTilgang(id: UUID, arrangorAnsattId: UUID, gjennomforingId: UUID) {
-		val harAlleredeTilgang = hentGjennomforingerForAnsatt(arrangorAnsattId)
+	override fun leggTil(id: UUID, arrangorAnsattId: UUID, gjennomforingId: UUID) {
+		val harAlleredeTilgang = hentAlleForAnsatt(arrangorAnsattId)
 			.contains(gjennomforingId)
 
 		if (harAlleredeTilgang) {
@@ -25,7 +26,7 @@ open class ArrangorAnsattGjennomforingTilgangService(
 			)
 		}
 
-		arrangorAnsattGjennomforingTilgangRepository.opprettTilgang(
+		mineDeltakerlisterRepository.leggTil(
 			id = id,
 			arrangorAnsattId = arrangorAnsattId,
 			gjennomforingId = gjennomforingId,
@@ -35,25 +36,30 @@ open class ArrangorAnsattGjennomforingTilgangService(
 
 	}
 
-	open fun fjernTilgang(arrangorAnsattId: UUID, gjennomforingId: UUID) {
-		arrangorAnsattGjennomforingTilgangRepository.fjernTilgang(arrangorAnsattId, gjennomforingId)
+	override fun fjern(arrangorAnsattId: UUID, gjennomforingId: UUID) {
+		mineDeltakerlisterRepository.fjern(arrangorAnsattId, gjennomforingId)
 	}
 
-	fun fjernTilgangTilGjennomforinger(arrangorAnsattId: UUID, arrangorId: UUID) {
-		val tilganger = arrangorAnsattGjennomforingTilgangRepository
-			.hentAktiveGjennomforingTilgangerForAnsatt(arrangorAnsattId)
+	override fun fjernGjennomforinger(arrangorAnsattId: UUID, arrangorId: UUID) {
+		val tilganger = mineDeltakerlisterRepository
+			.hent(arrangorAnsattId)
 		val gjennomforinger = gjennomforingService.getByArrangorId(arrangorId)
 
 		transactionTemplate.executeWithoutResult {
 			tilganger
 				.filter { tilgang -> gjennomforinger.any { tilgang.gjennomforingId == it.id } }
-				.forEach { fjernTilgang(arrangorAnsattId, it.gjennomforingId) }
+				.forEach { fjern(arrangorAnsattId, it.gjennomforingId) }
 		}
 	}
 
-	fun hentGjennomforingerForAnsatt(ansattId: UUID): List<UUID> {
-		return arrangorAnsattGjennomforingTilgangRepository.hentAktiveGjennomforingTilgangerForAnsatt(ansattId)
+	override fun hentAlleForAnsatt(ansattId: UUID): List<UUID> {
+		return mineDeltakerlisterRepository.hent(ansattId)
 			.map { it.gjennomforingId }
+	}
+
+	override fun harLagtTilDeltakerliste(ansattId: UUID, gjennomforingId: UUID): Boolean {
+		val gjennomforinger = hentAlleForAnsatt(ansattId)
+		return gjennomforinger.contains(gjennomforingId)
 	}
 
 }

--- a/tilgangskontroll-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/MineDeltakerlisterServiceImpl.kt
+++ b/tilgangskontroll-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/MineDeltakerlisterServiceImpl.kt
@@ -17,7 +17,7 @@ open class MineDeltakerlisterServiceImpl(
 	private val defaultGyldigTil = ZonedDateTime.parse("3000-01-01T00:00:00.00000+00:00")
 
 	override fun leggTil(id: UUID, arrangorAnsattId: UUID, gjennomforingId: UUID) {
-		val harAlleredeTilgang = hentAlleForAnsatt(arrangorAnsattId)
+		val harAlleredeTilgang = hent(arrangorAnsattId)
 			.contains(gjennomforingId)
 
 		if (harAlleredeTilgang) {
@@ -40,7 +40,7 @@ open class MineDeltakerlisterServiceImpl(
 		mineDeltakerlisterRepository.fjern(arrangorAnsattId, gjennomforingId)
 	}
 
-	override fun fjernGjennomforinger(arrangorAnsattId: UUID, arrangorId: UUID) {
+	override fun fjernAlleHosArrangor(arrangorAnsattId: UUID, arrangorId: UUID) {
 		val tilganger = mineDeltakerlisterRepository
 			.hent(arrangorAnsattId)
 		val gjennomforinger = gjennomforingService.getByArrangorId(arrangorId)
@@ -52,13 +52,13 @@ open class MineDeltakerlisterServiceImpl(
 		}
 	}
 
-	override fun hentAlleForAnsatt(ansattId: UUID): List<UUID> {
+	override fun hent(ansattId: UUID): List<UUID> {
 		return mineDeltakerlisterRepository.hent(ansattId)
 			.map { it.gjennomforingId }
 	}
 
-	override fun harLagtTilDeltakerliste(ansattId: UUID, gjennomforingId: UUID): Boolean {
-		val gjennomforinger = hentAlleForAnsatt(ansattId)
+	override fun erLagtTil(ansattId: UUID, gjennomforingId: UUID): Boolean {
+		val gjennomforinger = hent(ansattId)
 		return gjennomforinger.contains(gjennomforingId)
 	}
 

--- a/tilgangskontroll-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/jobs/ArrangorAnsattGjennomforingTiltakStatistikkUpdater.kt
+++ b/tilgangskontroll-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/jobs/ArrangorAnsattGjennomforingTiltakStatistikkUpdater.kt
@@ -3,7 +3,7 @@ package no.nav.amt.tiltak.tilgangskontroll_tiltaksarrangor.tilgang.jobs
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tags
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
-import no.nav.amt.tiltak.tilgangskontroll_tiltaksarrangor.tilgang.ArrangorAnsattGjennomforingTilgangRepository
+import no.nav.amt.tiltak.tilgangskontroll_tiltaksarrangor.tilgang.MineDeltakerlisterRepository
 import no.nav.common.job.JobRunner
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Configuration
@@ -15,7 +15,7 @@ private const val gjennomforingerPerAnsatt = "amt_tiltak_antall_gjennomforinger_
 
 @Configuration
 open class ArrangorAnsattGjennomforingTiltakStatistikkUpdater(
-	private val repository: ArrangorAnsattGjennomforingTilgangRepository,
+	private val repository: MineDeltakerlisterRepository,
 	private val registry: MeterRegistry
 ) {
 
@@ -31,7 +31,7 @@ open class ArrangorAnsattGjennomforingTiltakStatistikkUpdater(
 	}
 
 	private fun runner() {
-		val data = repository.getAntallGjennomforingerPerAnsatt()
+		val data = repository.hentAntallPerAnsatt()
 		data.forEach { (ansattId, numberOfGjennomforinger) ->
 			val gauge = gjennomforingerPerAnsattGauges[ansattId]
 

--- a/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattGjennomforingTilgangRepositoryTest.kt
+++ b/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattGjennomforingTilgangRepositoryTest.kt
@@ -29,7 +29,7 @@ class ArrangorAnsattGjennomforingTilgangRepositoryTest : FunSpec({
 
 	val dataSource = SingletonPostgresContainer.getDataSource()
 
-	lateinit var repository: ArrangorAnsattGjennomforingTilgangRepository
+	lateinit var repository: MineDeltakerlisterRepository
 
 	lateinit var testRepository: TestDataRepository
 
@@ -39,7 +39,7 @@ class ArrangorAnsattGjennomforingTilgangRepositoryTest : FunSpec({
 
 		val parameterTemplate = NamedParameterJdbcTemplate(dataSource)
 
-		repository = ArrangorAnsattGjennomforingTilgangRepository(parameterTemplate)
+		repository = MineDeltakerlisterRepository(parameterTemplate)
 		testRepository = TestDataRepository(parameterTemplate)
 
 		DbTestDataUtils.cleanDatabase(dataSource)
@@ -57,7 +57,7 @@ class ArrangorAnsattGjennomforingTilgangRepositoryTest : FunSpec({
 		val gyldigFra = ZonedDateTime.now()
 		val gyldigTil = ZonedDateTime.now().plusHours(1)
 
-		repository.opprettTilgang(tilgangId, ARRANGOR_ANSATT_1.id, GJENNOMFORING_1.id, gyldigFra, gyldigTil)
+		repository.leggTil(tilgangId, ARRANGOR_ANSATT_1.id, GJENNOMFORING_1.id, gyldigFra, gyldigTil)
 
 		val tilgang = repository.get(tilgangId)
 
@@ -103,7 +103,7 @@ class ArrangorAnsattGjennomforingTilgangRepositoryTest : FunSpec({
 			)
 		)
 
-		val tilganger = repository.hentAktiveGjennomforingTilgangerForAnsatt(ansattId)
+		val tilganger = repository.hent(ansattId)
 
 		tilganger.size shouldBe 1
 		tilganger.any { it.gjennomforingId == gjennomforing1Id } shouldBe true
@@ -133,7 +133,7 @@ class ArrangorAnsattGjennomforingTilgangRepositoryTest : FunSpec({
 			)
 		)
 
-		repository.fjernTilgang(ansattId, gjennomforingId)
+		repository.fjern(ansattId, gjennomforingId)
 
 		val tilgang = repository.get(tilgangId)
 
@@ -142,7 +142,7 @@ class ArrangorAnsattGjennomforingTilgangRepositoryTest : FunSpec({
 
 	test("getAntallGjennomforingerPerAnsatt") {
 		DbTestDataUtils.cleanAndInitDatabaseWithTestData(dataSource)
-		val data = repository.getAntallGjennomforingerPerAnsatt()
+		val data = repository.hentAntallPerAnsatt()
 
 		data.size shouldBe 1
 		data[ARRANGOR_ANSATT_1.id] shouldNotBe null

--- a/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattGjennomforingTilgangRepositoryTest.kt
+++ b/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattGjennomforingTilgangRepositoryTest.kt
@@ -85,7 +85,7 @@ class ArrangorAnsattGjennomforingTilgangRepositoryTest : FunSpec({
 		val tilgangId1 = UUID.randomUUID()
 		val tilgangId2 = UUID.randomUUID()
 
-		testRepository.insertArrangorAnsattGjennomforingTilgang(
+		testRepository.insertMineDeltakerlister(
 			GJENNOMFORING_TILGANG_1.copy(
 				id = tilgangId1,
 				ansattId = ansattId,
@@ -93,7 +93,7 @@ class ArrangorAnsattGjennomforingTilgangRepositoryTest : FunSpec({
 			)
 		)
 
-		testRepository.insertArrangorAnsattGjennomforingTilgang(
+		testRepository.insertMineDeltakerlister(
 			GJENNOMFORING_TILGANG_1.copy(
 				id = tilgangId2,
 				ansattId = ansattId,
@@ -125,7 +125,7 @@ class ArrangorAnsattGjennomforingTilgangRepositoryTest : FunSpec({
 		val gjennomforingId = GJENNOMFORING_1.id
 		val tilgangId = UUID.randomUUID()
 
-		testRepository.insertArrangorAnsattGjennomforingTilgang(
+		testRepository.insertMineDeltakerlister(
 			GJENNOMFORING_TILGANG_1.copy(
 				id = tilgangId,
 				ansattId = ansattId,

--- a/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattGjennomforingTilgangServiceTest.kt
+++ b/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattGjennomforingTilgangServiceTest.kt
@@ -32,13 +32,13 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 
 	val dataSource = SingletonPostgresContainer.getDataSource()
 
-	lateinit var repository: ArrangorAnsattGjennomforingTilgangRepository
+	lateinit var repository: MineDeltakerlisterRepository
 
 	lateinit var testRepository: TestDataRepository
 
 	lateinit var transactionTemplate: TransactionTemplate
 
-	lateinit var service: ArrangorAnsattGjennomforingTilgangService
+	lateinit var service: MineDeltakerlisterServiceImpl
 
 	lateinit var gjennomforingService: GjennomforingService
 
@@ -48,7 +48,7 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 
 		val template = NamedParameterJdbcTemplate(dataSource)
 
-		repository = ArrangorAnsattGjennomforingTilgangRepository(template)
+		repository = MineDeltakerlisterRepository(template)
 
 		testRepository = TestDataRepository(template)
 
@@ -56,7 +56,7 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 
 		gjennomforingService = mockk()
 
-		service = ArrangorAnsattGjennomforingTilgangService(repository, gjennomforingService, transactionTemplate)
+		service = MineDeltakerlisterServiceImpl(repository, gjennomforingService, transactionTemplate)
 
 
 		DbTestDataUtils.cleanDatabase(dataSource)
@@ -99,11 +99,11 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 			)
 		)
 
-		service.fjernTilgang(ARRANGOR_ANSATT_1.id, GJENNOMFORING_1.id)
+		service.fjern(ARRANGOR_ANSATT_1.id, GJENNOMFORING_1.id)
 
 		eventually(5.seconds) {
 			val aktiveTilganger =
-				repository.hentAktiveGjennomforingTilgangerForAnsatt(ARRANGOR_ANSATT_1.id)
+				repository.hent(ARRANGOR_ANSATT_1.id)
 
 			aktiveTilganger shouldHaveSize 1
 			aktiveTilganger.first().gjennomforingId shouldBe GJENNOMFORING_2.id
@@ -120,7 +120,7 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 		)
 
 		shouldThrowExactly<IllegalStateException> {
-			service.opprettTilgang(UUID.randomUUID(), ARRANGOR_ANSATT_1.id, GJENNOMFORING_1.id)
+			service.leggTil(UUID.randomUUID(), ARRANGOR_ANSATT_1.id, GJENNOMFORING_1.id)
 		}
 	}
 
@@ -169,12 +169,12 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 				lopenr = 2,
 		))
 
-		var aktiveGjennomforingTilganger = repository.hentAktiveGjennomforingTilgangerForAnsatt(ARRANGOR_ANSATT_1.id)
+		var aktiveGjennomforingTilganger = repository.hent(ARRANGOR_ANSATT_1.id)
 		aktiveGjennomforingTilganger shouldHaveSize 2
 
-		service.fjernTilgangTilGjennomforinger(ARRANGOR_ANSATT_1.id, ARRANGOR_1.id)
+		service.fjernGjennomforinger(ARRANGOR_ANSATT_1.id, ARRANGOR_1.id)
 
-		aktiveGjennomforingTilganger = repository.hentAktiveGjennomforingTilgangerForAnsatt(ARRANGOR_ANSATT_1.id)
+		aktiveGjennomforingTilganger = repository.hent(ARRANGOR_ANSATT_1.id)
 		aktiveGjennomforingTilganger shouldHaveSize 0
 	}
 

--- a/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattTilgangServiceImplTest.kt
+++ b/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattTilgangServiceImplTest.kt
@@ -7,7 +7,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.amt.tiltak.core.domain.arrangor.Ansatt
 import no.nav.amt.tiltak.core.domain.arrangor.Arrangor
-import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle
 import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle.KOORDINATOR
 import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle.VEILEDER
 import no.nav.amt.tiltak.core.domain.tiltak.Deltaker
@@ -144,8 +143,8 @@ class ArrangorAnsattTilgangServiceImplTest {
 		)
 
 		every {
-			gjennomforingService.getGjennomforing(any())
-		} returns gjennomforing
+			gjennomforingService.getArrangorId(gjennomforingId)
+		} returns arrangorId
 	}
 	@Test
 	fun `verifiserTilgangTilGjennomforing - koordinator har ikke lagt til deltakerliste - skal kaste exception`() {
@@ -346,7 +345,7 @@ class ArrangorAnsattTilgangServiceImplTest {
 		every { ansattRolleService.hentAktiveRoller(ansattId) } returns listOf(
 			no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRoller(
 				arrangorId = arrangorId,
-				roller = listOf(ArrangorAnsattRolle.VEILEDER)
+				roller = listOf(VEILEDER)
 			)
 		)
 		every { arrangorService.getOrCreateArrangor(organisasjonsnummer) } returns Arrangor(

--- a/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattTilgangServiceImplTest.kt
+++ b/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/ArrangorAnsattTilgangServiceImplTest.kt
@@ -2,7 +2,6 @@ package no.nav.amt.tiltak.tilgangskontroll_tiltaksarrangor.tilgang
 
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrowExactly
-import io.kotest.core.spec.style.FunSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -10,21 +9,24 @@ import no.nav.amt.tiltak.core.domain.arrangor.Ansatt
 import no.nav.amt.tiltak.core.domain.arrangor.Arrangor
 import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle
 import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle.KOORDINATOR
+import no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRolle.VEILEDER
 import no.nav.amt.tiltak.core.domain.tiltak.Deltaker
 import no.nav.amt.tiltak.core.domain.tiltak.DeltakerStatus
 import no.nav.amt.tiltak.core.domain.tiltak.Gjennomforing
 import no.nav.amt.tiltak.core.domain.tiltak.Tiltak
-import no.nav.amt.tiltak.core.exceptions.UnauthorizedException
 import no.nav.amt.tiltak.core.port.*
 import no.nav.amt.tiltak.test.database.SingletonPostgresContainer
 import no.nav.amt.tiltak.tilgangskontroll_tiltaksarrangor.altinn.AltinnService
 import no.nav.amt.tiltak.tilgangskontroll_tiltaksarrangor.altinn.ArrangorAnsattRoller
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.springframework.jdbc.datasource.DataSourceTransactionManager
 import org.springframework.transaction.support.TransactionTemplate
+import org.springframework.web.server.ResponseStatusException
 import java.time.LocalDateTime
 import java.util.*
 
-class ArrangorAnsattTilgangServiceImplTest : FunSpec({
+class ArrangorAnsattTilgangServiceImplTest {
 
 	lateinit var arrangorAnsattService: ArrangorAnsattService
 
@@ -34,7 +36,7 @@ class ArrangorAnsattTilgangServiceImplTest : FunSpec({
 
 	lateinit var arrangorAnsattTilgangServiceImpl: ArrangorAnsattTilgangServiceImpl
 
-	lateinit var arrangorAnsattGjennomforingTilgangService: MineDeltakerlisterServiceImpl
+	lateinit var mineDeltakerlisterService: MineDeltakerlisterServiceImpl
 
 	lateinit var altinnService: AltinnService
 
@@ -104,14 +106,15 @@ class ArrangorAnsattTilgangServiceImplTest : FunSpec({
 		gjennomforingId = gjennomforingId,
 		erSkjermet = true
 	)
-	beforeEach {
+	@BeforeEach
+	fun beforeEach() {
 		arrangorAnsattService = mockk()
 
 		ansattRolleService = mockk(relaxUnitFun = true)
 
 		deltakerService = mockk()
 
-		arrangorAnsattGjennomforingTilgangService = mockk(relaxUnitFun = true)
+		mineDeltakerlisterService = mockk(relaxUnitFun = true)
 
 		altinnService = mockk()
 
@@ -121,9 +124,11 @@ class ArrangorAnsattTilgangServiceImplTest : FunSpec({
 
 		arrangorVeilederService = mockk()
 
+		gjennomforingService = mockk()
+
 		arrangorAnsattTilgangServiceImpl = ArrangorAnsattTilgangServiceImpl(
 			arrangorAnsattService, ansattRolleService,
-			deltakerService, altinnService, arrangorAnsattGjennomforingTilgangService, arrangorVeilederService,
+			deltakerService, gjennomforingService, altinnService, mineDeltakerlisterService, arrangorVeilederService,
 			arrangorService, TransactionTemplate(DataSourceTransactionManager(datasource))
 		)
 
@@ -139,6 +144,16 @@ class ArrangorAnsattTilgangServiceImplTest : FunSpec({
 		)
 
 		every {
+			gjennomforingService.getGjennomforing(any())
+		} returns gjennomforing
+	}
+	@Test
+	fun `verifiserTilgangTilGjennomforing - koordinator har ikke lagt til deltakerliste - skal kaste exception`() {
+		every {
+			mineDeltakerlisterService.hent(ansattId)
+		} returns emptyList()
+
+		every {
 			ansattRolleService.hentAktiveRoller(any())
 		} returns listOf(
 			no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRoller(
@@ -147,60 +162,169 @@ class ArrangorAnsattTilgangServiceImplTest : FunSpec({
 			)
 		)
 
-		every {
-			gjennomforingService.getGjennomforing(any())
-		} returns gjennomforing
-	}
-
-	test("verifiserTilgangTilGjennomforing skal kaste exception hvis ikke tilgang") {
-		every {
-			arrangorAnsattGjennomforingTilgangService.hentAlleForAnsatt(ansattId)
-		} returns emptyList()
-
-		shouldThrowExactly<UnauthorizedException> {
+		shouldThrowExactly<ResponseStatusException> {
 			arrangorAnsattTilgangServiceImpl.verifiserTilgangTilGjennomforing(ansattId, gjennomforingId)
 		}
 	}
 
-	test("verifiserTilgangTilGjennomforing skal ikke kaste exception hvis tilgang") {
+	@Test
+	fun `verifiserTilgangTilGjennomforing - koordinator lagt til deltakerliste - skal ikke kaste exception`() {
 		every {
-			arrangorAnsattGjennomforingTilgangService.hentAlleForAnsatt(ansattId)
+			mineDeltakerlisterService.hent(ansattId)
 		} returns listOf(gjennomforingId)
+
+		every {
+			ansattRolleService.hentAktiveRoller(any())
+		} returns listOf(
+			no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRoller(
+				arrangorId = arrangorId,
+				roller = listOf(KOORDINATOR)
+			)
+		)
 
 		shouldNotThrow<Throwable> {
 			arrangorAnsattTilgangServiceImpl.verifiserTilgangTilGjennomforing(ansattId, gjennomforingId)
 		}
 	}
 
-	test("verifiserTilgangTilDeltaker skal ikke kaste exception hvis tilgang") {
+	@Test
+	fun `verifiserTilgangTilGjennomforing - veileder rolle - skal kaste exception`() {
+		every {
+			mineDeltakerlisterService.hent(ansattId)
+		} returns listOf(gjennomforingId)
+
+		every {
+			ansattRolleService.hentAktiveRoller(any())
+		} returns listOf(
+			no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRoller(
+				arrangorId = arrangorId,
+				roller = listOf(VEILEDER)
+			)
+		)
+
+		shouldThrowExactly<ResponseStatusException> {
+			arrangorAnsattTilgangServiceImpl.verifiserTilgangTilGjennomforing(ansattId, gjennomforingId)
+		}
+	}
+
+	@Test
+	fun `verifiserTilgangTilDeltaker - veileder rolle med tilgang - skal ikke kaste exception`() {
+		every {
+			arrangorVeilederService.erVeilederFor(ansattId, deltakerId)
+		} returns true
+
+		every {
+			ansattRolleService.hentAktiveRoller(any())
+		} returns listOf(
+			no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRoller(
+				arrangorId = arrangorId,
+				roller = listOf(VEILEDER)
+			)
+		)
+
+		every {
+			deltakerService.hentDeltaker(deltakerId)
+		} returns deltaker
+
+		shouldNotThrow<ResponseStatusException> {
+			arrangorAnsattTilgangServiceImpl.verifiserTilgangTilDeltaker(ansattId, deltakerId)
+		}
+	}
+	@Test
+	fun `verifiserTilgangTilDeltaker - veileder uten tilgang til arrangør - skal kaste exception`() {
+		every {
+			arrangorVeilederService.erVeilederFor(ansattId, deltakerId)
+		} returns true
+
+		every {
+			ansattRolleService.hentAktiveRoller(any())
+		} returns emptyList()
+
+		every {
+			deltakerService.hentDeltaker(deltakerId)
+		} returns deltaker
+
+		shouldThrowExactly<ResponseStatusException> {
+			arrangorAnsattTilgangServiceImpl.verifiserTilgangTilDeltaker(ansattId, deltakerId)
+		}
+
+	}
+
+	@Test
+	fun `verifiserTilgangTilDeltaker - veileder med tilgang til deltaker, og annen arrangør - skal kaste exception`() {
+		every {
+			arrangorVeilederService.erVeilederFor(ansattId, deltakerId)
+		} returns true
+
+		every {
+			ansattRolleService.hentAktiveRoller(any())
+		} returns listOf(
+			no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRoller(
+				arrangorId = UUID.randomUUID(),
+				roller = listOf(VEILEDER)
+			)
+		)
+
+		every {
+			deltakerService.hentDeltaker(deltakerId)
+		} returns deltaker
+
+		shouldThrowExactly<ResponseStatusException> {
+			arrangorAnsattTilgangServiceImpl.verifiserTilgangTilDeltaker(ansattId, deltakerId)
+		}
+
+	}
+
+	@Test
+	fun `verifiserTilgangTilDeltaker - koordinator har tilgang til arrangør - skal ikke kaste exception`() {
 		every {
 			deltakerService.hentDeltaker(deltakerId)
 		} returns deltaker
 
 		every {
-			arrangorAnsattGjennomforingTilgangService.hentAlleForAnsatt(ansattId)
+			mineDeltakerlisterService.hent(ansattId)
 		} returns listOf(gjennomforingId)
+
+		every {
+			ansattRolleService.hentAktiveRoller(any())
+		} returns listOf(
+			no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRoller(
+				arrangorId = arrangorId,
+				roller = listOf(KOORDINATOR)
+			)
+		)
 
 		shouldNotThrow<Throwable> {
 			arrangorAnsattTilgangServiceImpl.verifiserTilgangTilDeltaker(ansattId, deltakerId)
 		}
 	}
 
-	test("verifiserTilgangTilDeltaker skal kaste exception hvis ikke tilgang til gjennomforing") {
+	@Test
+	fun `verifiserTilgangTilDeltaker - koordinator ikke tilgang til arrangør - skal kaste exception`() {
 		every {
 			deltakerService.hentDeltaker(deltakerId)
 		} returns deltaker
 
 		every {
-			arrangorAnsattGjennomforingTilgangService.hentAlleForAnsatt(ansattId)
+			mineDeltakerlisterService.hent(ansattId)
 		} returns emptyList()
 
-		shouldThrowExactly<UnauthorizedException> {
+		every {
+			ansattRolleService.hentAktiveRoller(any())
+		} returns listOf(
+			no.nav.amt.tiltak.core.domain.tilgangskontroll.ArrangorAnsattRoller(
+				arrangorId = UUID.randomUUID(),
+				roller = listOf(KOORDINATOR)
+			)
+		)
+
+		shouldThrowExactly<ResponseStatusException> {
 			arrangorAnsattTilgangServiceImpl.verifiserTilgangTilDeltaker(ansattId, deltakerId)
 		}
 	}
 
-	test("synkroniserRettigheterMedAltinn - skal legge til nye roller fra Altinn") {
+	@Test
+	fun `synkroniserRettigheterMedAltinn - skal legge til nye roller fra Altinn`() {
 		val ansattPersonligIdent = "1234"
 		val ansattId = UUID.randomUUID()
 
@@ -238,7 +362,8 @@ class ArrangorAnsattTilgangServiceImplTest : FunSpec({
 		verify(exactly = 1) { ansattRolleService.opprettRolle(any(), ansattId, arrangorId, KOORDINATOR) }
 	}
 
-	test("synkroniserRettigheterMedAltinn - skal ikke legge til rolle hvis allerede finnes") {
+	@Test
+	fun `synkroniserRettigheterMedAltinn - skal ikke legge til rolle hvis allerede finnes`() {
 		val ansattPersonligIdent = "1234"
 		val ansattId = UUID.randomUUID()
 
@@ -276,7 +401,8 @@ class ArrangorAnsattTilgangServiceImplTest : FunSpec({
 		verify(exactly = 0) { ansattRolleService.opprettRolle(any(), any(), any(), any()) }
 	}
 
-	test("synkroniserRettigheterMedAltinn - skal fjerne roller som ikke finnes i Altinn") {
+	@Test
+	fun `synkroniserRettigheterMedAltinn - skal fjerne roller som ikke finnes i Altinn`() {
 	val ansattPersonligIdent = "1234"
 		val ansattId = UUID.randomUUID()
 
@@ -320,11 +446,12 @@ class ArrangorAnsattTilgangServiceImplTest : FunSpec({
 		arrangorAnsattTilgangServiceImpl.synkroniserRettigheterMedAltinn(ansattPersonligIdent)
 
 		verify(exactly = 1) { ansattRolleService.deaktiverRolleHosArrangor(ansattId, arrangorId, KOORDINATOR) }
-		verify(exactly = 1) { arrangorAnsattGjennomforingTilgangService.fjernGjennomforinger(ansattId, arrangorId) }
+		verify(exactly = 1) { mineDeltakerlisterService.fjernAlleHosArrangor(ansattId, arrangorId) }
 
 	}
 
-	test("synkroniserRettigheterMedAltinn - skal returne tidlig hvis ingen rolle og ikke ansatt") {
+	@Test
+	fun `synkroniserRettigheterMedAltinn - skal returne tidlig hvis ingen rolle og ikke ansatt`() {
 		val ansattPersonligIdent = "1234"
 
 		every { altinnService.hentTiltaksarrangorRoller(ansattPersonligIdent) } returns listOf()
@@ -334,6 +461,6 @@ class ArrangorAnsattTilgangServiceImplTest : FunSpec({
 
 		verify(exactly = 0) { ansattRolleService.opprettRolle(any(), any(), any(), any()) }
 		verify(exactly = 0) { ansattRolleService.deaktiverRolleHosArrangor(any(), any(), any()) }
-		verify(exactly = 0) { arrangorAnsattGjennomforingTilgangService.fjernGjennomforinger(any(), any()) }
+		verify(exactly = 0) { mineDeltakerlisterService.fjernAlleHosArrangor(any(), any()) }
 	}
-})
+}

--- a/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/MineDeltakerlisterServiceTest.kt
+++ b/tilgangskontroll-tiltaksarrangor/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksarrangor/tilgang/MineDeltakerlisterServiceTest.kt
@@ -28,7 +28,7 @@ import org.springframework.transaction.support.TransactionTemplate
 import java.util.*
 import kotlin.time.Duration.Companion.seconds
 
-class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
+class MineDeltakerlisterServiceTest : FunSpec({
 
 	val dataSource = SingletonPostgresContainer.getDataSource()
 
@@ -74,8 +74,8 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 		)
 	}
 
-	test("fjernTilgang - skal fjerne tilgang til gjennomføring") {
-		testRepository.insertArrangorAnsattGjennomforingTilgang(
+	test("fjern - skal fjerne tilgang til gjennomføring") {
+		testRepository.insertMineDeltakerlister(
 			GJENNOMFORING_TILGANG_1.copy(
 				id = UUID.randomUUID(),
 				ansattId = ARRANGOR_ANSATT_1.id,
@@ -83,7 +83,7 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 			)
 		)
 
-		testRepository.insertArrangorAnsattGjennomforingTilgang(
+		testRepository.insertMineDeltakerlister(
 			GJENNOMFORING_TILGANG_1.copy(
 				id = UUID.randomUUID(),
 				ansattId = ARRANGOR_ANSATT_1.id,
@@ -91,7 +91,7 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 			)
 		)
 
-		testRepository.insertArrangorAnsattGjennomforingTilgang(
+		testRepository.insertMineDeltakerlister(
 			GJENNOMFORING_TILGANG_1.copy(
 				id = UUID.randomUUID(),
 				ansattId = ARRANGOR_ANSATT_1.id,
@@ -110,8 +110,8 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 		}
 	}
 
-	test("opprettTilgang - skal kaste exception hvis tilgang er allerede opprettet") {
-		testRepository.insertArrangorAnsattGjennomforingTilgang(
+	test("leggTil - skal kaste exception hvis tilgang er allerede opprettet") {
+		testRepository.insertMineDeltakerlister(
 			GJENNOMFORING_TILGANG_1.copy(
 				id = UUID.randomUUID(),
 				ansattId = ARRANGOR_ANSATT_1.id,
@@ -124,11 +124,11 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 		}
 	}
 
-	test("fjernTilgangTilGjennomforinger - skal fjerne tilgang til gjennomforing hos arrangor") {
+	test("fjernAlleHosArrangor - skal fjerne tilgang til gjennomforing hos arrangor") {
 		val id1 = UUID.randomUUID()
 		val id2 = UUID.randomUUID()
 
-		testRepository.insertArrangorAnsattGjennomforingTilgang(
+		testRepository.insertMineDeltakerlister(
 			GJENNOMFORING_TILGANG_1.copy(
 				id = id1,
 				ansattId = ARRANGOR_ANSATT_1.id,
@@ -136,7 +136,7 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 			)
 		)
 
-		testRepository.insertArrangorAnsattGjennomforingTilgang(
+		testRepository.insertMineDeltakerlister(
 			GJENNOMFORING_TILGANG_1.copy(
 				id = id2,
 				ansattId = ARRANGOR_ANSATT_1.id,
@@ -172,7 +172,7 @@ class ArrangorAnsattGjennomforingTilgangServiceTest : FunSpec({
 		var aktiveGjennomforingTilganger = repository.hent(ARRANGOR_ANSATT_1.id)
 		aktiveGjennomforingTilganger shouldHaveSize 2
 
-		service.fjernGjennomforinger(ARRANGOR_ANSATT_1.id, ARRANGOR_1.id)
+		service.fjernAlleHosArrangor(ARRANGOR_ANSATT_1.id, ARRANGOR_1.id)
 
 		aktiveGjennomforingTilganger = repository.hent(ARRANGOR_ANSATT_1.id)
 		aktiveGjennomforingTilganger shouldHaveSize 0

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/services/GjennomforingServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/services/GjennomforingServiceImpl.kt
@@ -95,6 +95,10 @@ class GjennomforingServiceImpl(
 		}
 	}
 
+	override fun getArrangorId(gjennomforingId: UUID): UUID {
+		return gjennomforingRepository.get(gjennomforingId)?.arrangorId ?: throw IllegalStateException("Fant ikke gjennomføring med id $gjennomforingId")
+	}
+
 	override fun getByLopenr(lopenr: Int): List<Gjennomforing> {
 		return gjennomforingRepository.getByLopenr(lopenr)
 			.map {

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/metrics/GjennomforingMetricRepositoryTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/tiltak/metrics/GjennomforingMetricRepositoryTest.kt
@@ -52,8 +52,8 @@ internal class GjennomforingMetricRepositoryTest : FunSpec({
 
 				testRepository.insertTiltak(tiltak)
 				testRepository.insertGjennomforing(gjennomforing)
-				testRepository.insertArrangorAnsattGjennomforingTilgang(tilgang)
-				testRepository.insertArrangorAnsattGjennomforingTilgang(tilgang2)
+				testRepository.insertMineDeltakerlister(tilgang)
+				testRepository.insertMineDeltakerlister(tilgang2)
 
 			}
 		}


### PR DESCRIPTION
- Separerer ut deltakerlister som ansatt har valgt å legge til fra tilgangshåndtering
- Fikser feil som gjør at man fikk tilgang hvis man hadde en rolle hos en annen arrangør enn man gjorde requests mot
    + Beholdt tilsvarende metode `arrangorAnsattTilgangService.verifiserHarRolleAnywhere` for å kunne feile requester før 
man har hentet info som er nødvendig for å sjekke at personen har tilgang til riktig arrangør, men mulig den burde fjernes.
    + https://trello.com/c/V6Uv0CR7/818-arrang%C3%B8rer-f%C3%A5r-tilgang-selv-om-de-har-altinn-rettighet-hos-feil-bedrift
- Legger inn støtte for tiltaksarrangør veileder https://trello.com/c/lmhTbH1m/807-gi-api-tilganger-til-ta-veileder
- Fjerner caching i tilgangshåndtering som bare var nødvendig fordi man ønsker ofte å hente ut AnsattId og dette ble gjort ved å hente hele domeneobjektet isteden for å hente id direkte fra service som eier id'en
- Flytter tilgangshåndering fra ArrangørVeilederService til controller for å gjøre den mer synlig og for å unngå sirkulære dependencier
