### PR TITLE
fjerner dobbelt oppslag av gjennomføringer i DB

### DIFF
--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/services/GjennomforingServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/services/GjennomforingServiceImpl.kt
@@ -77,15 +77,19 @@ class GjennomforingServiceImpl(
 
 	override fun getGjennomforing(id: UUID): Gjennomforing {
 		return gjennomforingRepository.get(id)?.let { gjennomforingDbo ->
-			val (tiltak, arrangor) = getTiltakOgArrangor(gjennomforingDbo.tiltakId, gjennomforingDbo.arrangorId)
-			return@let gjennomforingDbo.toGjennomforing(tiltak, arrangor)
+			return@let getTiltakOgArrangorOgMapTilGjennomforing(gjennomforingDbo)
 		} ?: throw NoSuchElementException("Fant ikke gjennomforing: $id")
 	}
 
 	override fun getGjennomforinger(gjennomforingIder: List<UUID>): List<Gjennomforing> {
 		return gjennomforingRepository
 			.get(gjennomforingIder)
-			.map { getGjennomforing(it.id) }
+			.map { getTiltakOgArrangorOgMapTilGjennomforing(it) }
+	}
+
+	private fun getTiltakOgArrangorOgMapTilGjennomforing(gjennomforingDbo: GjennomforingDbo): Gjennomforing {
+		val (tiltak, arrangor) = getTiltakOgArrangor(gjennomforingDbo.tiltakId, gjennomforingDbo.arrangorId)
+		return gjennomforingDbo.toGjennomforing(tiltak, arrangor)
 	}
 
 	override fun getByArrangorId(arrangorId: UUID): List<Gjennomforing> {

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/services/GjennomforingServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/services/GjennomforingServiceImpl.kt
@@ -77,19 +77,18 @@ class GjennomforingServiceImpl(
 
 	override fun getGjennomforing(id: UUID): Gjennomforing {
 		return gjennomforingRepository.get(id)?.let { gjennomforingDbo ->
-			return@let getTiltakOgArrangorOgMapTilGjennomforing(gjennomforingDbo)
+			val (tiltak, arrangor) = getTiltakOgArrangor(gjennomforingDbo.tiltakId, gjennomforingDbo.arrangorId)
+			return@let gjennomforingDbo.toGjennomforing(tiltak, arrangor)
 		} ?: throw NoSuchElementException("Fant ikke gjennomforing: $id")
 	}
 
 	override fun getGjennomforinger(gjennomforingIder: List<UUID>): List<Gjennomforing> {
 		return gjennomforingRepository
 			.get(gjennomforingIder)
-			.map { getTiltakOgArrangorOgMapTilGjennomforing(it) }
-	}
-
-	private fun getTiltakOgArrangorOgMapTilGjennomforing(gjennomforingDbo: GjennomforingDbo): Gjennomforing {
-		val (tiltak, arrangor) = getTiltakOgArrangor(gjennomforingDbo.tiltakId, gjennomforingDbo.arrangorId)
-		return gjennomforingDbo.toGjennomforing(tiltak, arrangor)
+			.map {
+				val (tiltak, arrangor) = getTiltakOgArrangor(it.tiltakId, it.arrangorId)
+				it.toGjennomforing(tiltak, arrangor)
+			}
 	}
 
 	override fun getByArrangorId(arrangorId: UUID): List<Gjennomforing> {


### PR DESCRIPTION
Dette er første steg for å effektivisere api-kall for å hente gjennomføring, ref https://trello.com/c/pimTvhY3/795-trege-kall-i-amt-tiltak

Vi kan effektivisere en god del mer her, men siden jeg fikk en annen feil å se på tenker jeg dette er en god start, så kan jeg heller plukke opp ballen senere :) 