### PR TITLE
Legger til 3 nye endringsmelding typer

### DIFF
--- a/bff-nav_ansatt/src/main/kotlin/no/nav/amt/tiltak/bff/nav_ansatt/NavAnsattControllerService.kt
+++ b/bff-nav_ansatt/src/main/kotlin/no/nav/amt/tiltak/bff/nav_ansatt/NavAnsattControllerService.kt
@@ -1,6 +1,10 @@
 package no.nav.amt.tiltak.bff.nav_ansatt
 
-import no.nav.amt.tiltak.bff.nav_ansatt.dto.*
+import no.nav.amt.tiltak.bff.nav_ansatt.dto.DeltakerDto
+import no.nav.amt.tiltak.bff.nav_ansatt.dto.EndringsmeldingDto
+import no.nav.amt.tiltak.bff.nav_ansatt.dto.HentGjennomforingerDto
+import no.nav.amt.tiltak.bff.nav_ansatt.dto.TiltakDto
+import no.nav.amt.tiltak.bff.nav_ansatt.dto.toDto
 import no.nav.amt.tiltak.core.domain.tiltak.Deltaker
 import no.nav.amt.tiltak.core.domain.tiltak.Endringsmelding
 import no.nav.amt.tiltak.core.domain.tiltak.Gjennomforing
@@ -63,9 +67,24 @@ class NavAnsattControllerService(
 		id = id,
 		deltaker = deltakerDto,
 		status = status.toDto(),
-		innhold = innhold.toDto(),
+		innhold = innhold?.toDto(),
 		opprettetDato = opprettet,
+		type = type.toDto()
 	)
+
+	private fun Endringsmelding.Type.toDto(): EndringsmeldingDto.Type {
+		return when (this) {
+			Endringsmelding.Type.LEGG_TIL_OPPSTARTSDATO -> EndringsmeldingDto.Type.LEGG_TIL_OPPSTARTSDATO
+			Endringsmelding.Type.ENDRE_OPPSTARTSDATO -> EndringsmeldingDto.Type.ENDRE_OPPSTARTSDATO
+			Endringsmelding.Type.FORLENG_DELTAKELSE -> EndringsmeldingDto.Type.FORLENG_DELTAKELSE
+			Endringsmelding.Type.AVSLUTT_DELTAKELSE -> EndringsmeldingDto.Type.AVSLUTT_DELTAKELSE
+			Endringsmelding.Type.DELTAKER_IKKE_AKTUELL -> EndringsmeldingDto.Type.DELTAKER_IKKE_AKTUELL
+			Endringsmelding.Type.ENDRE_DELTAKELSE_PROSENT -> EndringsmeldingDto.Type.ENDRE_DELTAKELSE_PROSENT
+			Endringsmelding.Type.TILBY_PLASS -> EndringsmeldingDto.Type.TILBY_PLASS
+			Endringsmelding.Type.SETT_PAA_VENTELISTE -> EndringsmeldingDto.Type.SETT_PAA_VENTELISTE
+			Endringsmelding.Type.ENDRE_SLUTTDATO -> EndringsmeldingDto.Type.ENDRE_SLUTTDATO
+		}
+	}
 
 	private fun Deltaker.toDto() = DeltakerDto(
 		fornavn = fornavn,

--- a/bff-nav_ansatt/src/main/kotlin/no/nav/amt/tiltak/bff/nav_ansatt/dto/EndringsmeldingDto.kt
+++ b/bff-nav_ansatt/src/main/kotlin/no/nav/amt/tiltak/bff/nav_ansatt/dto/EndringsmeldingDto.kt
@@ -10,11 +10,14 @@ import java.util.*
 data class EndringsmeldingDto(
 	val id: UUID,
 	val deltaker: DeltakerDto,
-	val innhold: Innhold,
+	val innhold: Innhold?,
 	val status: Status,
 	val opprettetDato: ZonedDateTime,
+	val type: Type
 ) {
-	val type = innhold.type()
+	enum class Status {
+		AKTIV, TILBAKEKALT, UTDATERT, UTFORT
+	}
 
 	enum class Type {
 		LEGG_TIL_OPPSTARTSDATO,
@@ -23,10 +26,9 @@ data class EndringsmeldingDto(
 		AVSLUTT_DELTAKELSE,
 		DELTAKER_IKKE_AKTUELL,
 		ENDRE_DELTAKELSE_PROSENT,
-	}
-
-	enum class Status {
-		AKTIV, TILBAKEKALT, UTDATERT, UTFORT
+		TILBY_PLASS,
+		SETT_PAA_VENTELISTE,
+		ENDRE_SLUTTDATO
 	}
 
 	sealed class Innhold {
@@ -56,16 +58,9 @@ data class EndringsmeldingDto(
 			val gyldigFraDato: LocalDate?
 		) : Innhold()
 
-		fun type(): Type {
-			return when(this) {
-				is LeggTilOppstartsdatoInnhold -> Type.LEGG_TIL_OPPSTARTSDATO
-				is EndreOppstartsdatoInnhold -> Type.ENDRE_OPPSTARTSDATO
-				is ForlengDeltakelseInnhold -> Type.FORLENG_DELTAKELSE
-				is AvsluttDeltakelseInnhold -> Type.AVSLUTT_DELTAKELSE
-				is DeltakerIkkeAktuellInnhold -> Type.DELTAKER_IKKE_AKTUELL
-				is EndreDeltakelseProsentInnhold -> Type.ENDRE_DELTAKELSE_PROSENT
-			}
-		}
+		data class EndreSluttdatoInnhold(
+			val sluttdato: LocalDate
+		) : Innhold()
 	}
 }
 
@@ -86,6 +81,8 @@ fun Endringsmelding.Innhold.toDto(): EndringsmeldingDto.Innhold {
 				deltakelseProsent = this.deltakelseProsent,
 				gyldigFraDato = this.gyldigFraDato
 			)
+		is Endringsmelding.Innhold.EndreSluttdatoInnhold ->
+			EndringsmeldingDto.Innhold.EndreSluttdatoInnhold(sluttdato = this.sluttdato)
 	}
 }
 

--- a/bff-nav_ansatt/src/test/kotlin/no/nav/amt/tiltak/bff/nav_ansatt/NavAnsattControllerServiceTest.kt
+++ b/bff-nav_ansatt/src/test/kotlin/no/nav/amt/tiltak/bff/nav_ansatt/NavAnsattControllerServiceTest.kt
@@ -45,6 +45,7 @@ class NavAnsattControllerServiceTest {
 			opprettet = ZonedDateTime.now(),
 			status = Endringsmelding.Status.AKTIV,
 			innhold = Endringsmelding.Innhold.LeggTilOppstartsdatoInnhold(LocalDate.now()),
+			type = Endringsmelding.Type.LEGG_TIL_OPPSTARTSDATO
 		)
 
 		val deltaker = DELTAKER_1.toDeltaker(BRUKER_1, DELTAKER_1_STATUS_1)
@@ -78,6 +79,7 @@ class NavAnsattControllerServiceTest {
 			opprettet = ZonedDateTime.now(),
 			status = Endringsmelding.Status.AKTIV,
 			innhold = Endringsmelding.Innhold.LeggTilOppstartsdatoInnhold(LocalDate.now()),
+			type = Endringsmelding.Type.LEGG_TIL_OPPSTARTSDATO
 		)
 
 		every { endringsmeldingService.hentEndringsmeldingerForGjennomforing(gjennomforingId) } returns listOf(endringsmelding)
@@ -111,6 +113,7 @@ class NavAnsattControllerServiceTest {
 			opprettet = ZonedDateTime.now(),
 			status = Endringsmelding.Status.AKTIV,
 			innhold = Endringsmelding.Innhold.LeggTilOppstartsdatoInnhold(LocalDate.now()),
+			type = Endringsmelding.Type.LEGG_TIL_OPPSTARTSDATO
 		)
 
 		every { endringsmeldingService.hentEndringsmeldingerForGjennomforing(gjennomforingId) } returns listOf(endringsmelding)

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/DeltakerController.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/DeltakerController.kt
@@ -89,7 +89,7 @@ class DeltakerController(
 		arrangorAnsattTilgangService.verifiserTilgangTilDeltaker(ansatt.id, deltakerId)
 		verifiserErIkkeSkjult(deltakerId)
 
-		deltakerService.leggTilOppstartsdato(deltakerId, ansatt.id, request.oppstartsdato)
+		endringsmeldingService.opprettLeggTilOppstartsdatoEndringsmelding(deltakerId, ansatt.id, request.oppstartsdato)
 	}
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
@@ -103,7 +103,7 @@ class DeltakerController(
 		arrangorAnsattTilgangService.verifiserTilgangTilDeltaker(ansatt.id, deltakerId)
 		verifiserErIkkeSkjult(deltakerId)
 
-		deltakerService.endreOppstartsdato(deltakerId, ansatt.id, request.oppstartsdato)
+		endringsmeldingService.opprettEndreOppstartsdatoEndringsmelding(deltakerId, ansatt.id, request.oppstartsdato)
 	}
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
@@ -117,7 +117,7 @@ class DeltakerController(
 		arrangorAnsattTilgangService.verifiserTilgangTilDeltaker(ansatt.id, deltakerId)
 		verifiserErIkkeSkjult(deltakerId)
 
-		deltakerService.avsluttDeltakelse(deltakerId, ansatt.id, request.sluttdato, request.aarsak.toModel())
+		endringsmeldingService.opprettAvsluttDeltakelseEndringsmelding(deltakerId, ansatt.id, request.sluttdato, request.aarsak.toModel())
 	}
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
@@ -131,7 +131,7 @@ class DeltakerController(
 		arrangorAnsattTilgangService.verifiserTilgangTilDeltaker(ansatt.id, deltakerId)
 		verifiserErIkkeSkjult(deltakerId)
 
-		deltakerService.forlengDeltakelse(deltakerId, ansatt.id, request.sluttdato)
+		endringsmeldingService.opprettForlengDeltakelseEndringsmelding(deltakerId, ansatt.id, request.sluttdato)
 	}
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
@@ -148,7 +148,7 @@ class DeltakerController(
 		arrangorAnsattTilgangService.verifiserTilgangTilDeltaker(ansatt.id, deltakerId)
 		verifiserErIkkeSkjult(deltakerId)
 
-		deltakerService.endreDeltakelsesprosent(deltakerId, ansatt.id, body.deltakelseProsent, body.gyldigFraDato)
+		endringsmeldingService.opprettEndreDeltakelseProsentEndringsmelding(deltakerId, ansatt.id, body.deltakelseProsent, body.gyldigFraDato)
 	}
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
@@ -162,7 +162,47 @@ class DeltakerController(
 		arrangorAnsattTilgangService.verifiserTilgangTilDeltaker(ansatt.id, deltakerId)
 		verifiserErIkkeSkjult(deltakerId)
 
-		deltakerService.deltakerIkkeAktuell(deltakerId, ansatt.id, request.aarsak.toModel())
+		endringsmeldingService.opprettDeltakerIkkeAktuellEndringsmelding(deltakerId, ansatt.id, request.aarsak.toModel())
+	}
+
+	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
+	@PatchMapping("/{deltakerId}/tilby-plass")
+	fun tilbyPlass(
+		@PathVariable("deltakerId") deltakerId: UUID,
+	) {
+		val ansatt = hentInnloggetAnsatt()
+
+		arrangorAnsattTilgangService.verifiserTilgangTilDeltaker(ansatt.id, deltakerId)
+		verifiserErIkkeSkjult(deltakerId)
+
+		endringsmeldingService.opprettTilbyPlassEndringsmelding(deltakerId, ansatt.id)
+	}
+
+	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
+	@PatchMapping("/{deltakerId}/sett-paa-venteliste")
+	fun settPaaVenteliste(
+		@PathVariable("deltakerId") deltakerId: UUID,
+	) {
+		val ansatt = hentInnloggetAnsatt()
+
+		arrangorAnsattTilgangService.verifiserTilgangTilDeltaker(ansatt.id, deltakerId)
+		verifiserErIkkeSkjult(deltakerId)
+
+		endringsmeldingService.opprettSettPaaVentelisteEndringsmelding(deltakerId, ansatt.id)
+	}
+
+	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
+	@PatchMapping("/{deltakerId}/endre-sluttdato")
+	fun endreSluttdato(
+		@PathVariable("deltakerId") deltakerId: UUID,
+		@RequestBody request: EndreSluttdatoRequest,
+	) {
+		val ansatt = hentInnloggetAnsatt()
+
+		arrangorAnsattTilgangService.verifiserTilgangTilDeltaker(ansatt.id, deltakerId)
+		verifiserErIkkeSkjult(deltakerId)
+
+		endringsmeldingService.opprettEndresluttdatoEndringsmelding(deltakerId, ansatt.id, request.sluttdato)
 	}
 
 	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/EndringsmeldingController.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/EndringsmeldingController.kt
@@ -34,12 +34,7 @@ class EndringsmeldingController(
 			throw SkjultDeltakerException("Deltaker med id $deltakerId er skjult for tiltaksarrangør")
 
 		return endringsmeldingService.hentAktiveEndringsmeldingerForDeltaker(deltakerId)
-			.map {
-				EndringsmeldingDto(
-					id = it.id,
-					innhold = it.innhold.toDto(),
-				)
-			}
+			.map { it.toDto() }
 	}
 
 	@PatchMapping("/{id}/tilbakekall")

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/dto/EndringsmeldingDto.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/dto/EndringsmeldingDto.kt
@@ -8,9 +8,9 @@ import java.util.*
 
 data class EndringsmeldingDto(
 	val id: UUID,
-	val innhold: Innhold,
+	val innhold: Innhold?,
+	val type: Type
 ) {
-	val type = innhold.type()
 
 	enum class Type {
 		LEGG_TIL_OPPSTARTSDATO,
@@ -19,6 +19,9 @@ data class EndringsmeldingDto(
 		AVSLUTT_DELTAKELSE,
 		DELTAKER_IKKE_AKTUELL,
 		ENDRE_DELTAKELSE_PROSENT,
+		TILBY_PLASS,
+		SETT_PAA_VENTELISTE,
+		ENDRE_SLUTTDATO
 	}
 
 	sealed class Innhold {
@@ -48,17 +51,9 @@ data class EndringsmeldingDto(
 			val aarsak: DeltakerStatusAarsak,
 		) : Innhold()
 
-		fun type(): Type {
-			return when(this) {
-				is LeggTilOppstartsdatoInnhold -> Type.LEGG_TIL_OPPSTARTSDATO
-				is EndreOppstartsdatoInnhold -> Type.ENDRE_OPPSTARTSDATO
-				is ForlengDeltakelseInnhold -> Type.FORLENG_DELTAKELSE
-				is AvsluttDeltakelseInnhold -> Type.AVSLUTT_DELTAKELSE
-				is DeltakerIkkeAktuellInnhold -> Type.DELTAKER_IKKE_AKTUELL
-				is EndreDeltakelseProsentInnhold -> Type.ENDRE_DELTAKELSE_PROSENT
-			}
-		}
-
+		data class EndreSluttdatoInnhold(
+			val sluttdato: LocalDate
+		) : Innhold()
 	}
 
 }
@@ -80,7 +75,22 @@ fun Endringsmelding.Innhold.toDto(): EndringsmeldingDto.Innhold {
 				deltakelseProsent = this.deltakelseProsent,
 				gyldigFraDato = this.gyldigFraDato
 			)
+		is Endringsmelding.Innhold.EndreSluttdatoInnhold -> EndringsmeldingDto.Innhold.EndreSluttdatoInnhold(this.sluttdato)
 	}
 }
 
-fun Endringsmelding.toDto() = EndringsmeldingDto(id = id, innhold = innhold.toDto())
+fun Endringsmelding.Type.toDto(): EndringsmeldingDto.Type {
+	return when (this) {
+		Endringsmelding.Type.LEGG_TIL_OPPSTARTSDATO -> EndringsmeldingDto.Type.LEGG_TIL_OPPSTARTSDATO
+		Endringsmelding.Type.ENDRE_OPPSTARTSDATO -> EndringsmeldingDto.Type.ENDRE_OPPSTARTSDATO
+		Endringsmelding.Type.FORLENG_DELTAKELSE -> EndringsmeldingDto.Type.FORLENG_DELTAKELSE
+		Endringsmelding.Type.AVSLUTT_DELTAKELSE -> EndringsmeldingDto.Type.AVSLUTT_DELTAKELSE
+		Endringsmelding.Type.DELTAKER_IKKE_AKTUELL -> EndringsmeldingDto.Type.DELTAKER_IKKE_AKTUELL
+		Endringsmelding.Type.ENDRE_DELTAKELSE_PROSENT -> EndringsmeldingDto.Type.ENDRE_DELTAKELSE_PROSENT
+		Endringsmelding.Type.TILBY_PLASS -> EndringsmeldingDto.Type.TILBY_PLASS
+		Endringsmelding.Type.SETT_PAA_VENTELISTE -> EndringsmeldingDto.Type.SETT_PAA_VENTELISTE
+		Endringsmelding.Type.ENDRE_SLUTTDATO -> EndringsmeldingDto.Type.ENDRE_SLUTTDATO
+	}
+}
+
+fun Endringsmelding.toDto() = EndringsmeldingDto(id = id, innhold = innhold?.toDto(), type=type.toDto())

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/request/EndreSluttdatoRequest.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/request/EndreSluttdatoRequest.kt
@@ -1,0 +1,7 @@
+package no.nav.amt.tiltak.bff.tiltaksarrangor.request
+
+import java.time.LocalDate
+
+data class EndreSluttdatoRequest (
+	val sluttdato: LocalDate,
+)

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Endringsmelding.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Endringsmelding.kt
@@ -12,12 +12,24 @@ data class Endringsmelding(
 	val opprettetAvArrangorAnsattId: UUID,
 	val opprettet: ZonedDateTime,
 	val status: Status,
-	val innhold: Innhold,
+	val innhold: Innhold?,
+	val type: Type
 ) {
 	enum class Status {
 		AKTIV, TILBAKEKALT, UTDATERT, UTFORT
 	}
 
+	enum class Type {
+		LEGG_TIL_OPPSTARTSDATO,
+		ENDRE_OPPSTARTSDATO,
+		FORLENG_DELTAKELSE,
+		AVSLUTT_DELTAKELSE,
+		DELTAKER_IKKE_AKTUELL,
+		ENDRE_DELTAKELSE_PROSENT,
+		TILBY_PLASS,
+		SETT_PAA_VENTELISTE,
+		ENDRE_SLUTTDATO
+	}
 	sealed class Innhold {
 		data class LeggTilOppstartsdatoInnhold(
 			val oppstartsdato: LocalDate
@@ -43,6 +55,10 @@ data class Endringsmelding(
 		data class EndreDeltakelseProsentInnhold(
 			val deltakelseProsent: Int,
 			val gyldigFraDato: LocalDate?
+		) : Innhold()
+
+		data class EndreSluttdatoInnhold(
+			val sluttdato: LocalDate
 		) : Innhold()
 	}
 }

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/DeltakerService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/DeltakerService.kt
@@ -1,7 +1,9 @@
 package no.nav.amt.tiltak.core.port
 
-import no.nav.amt.tiltak.core.domain.tiltak.*
-import java.time.LocalDate
+import no.nav.amt.tiltak.core.domain.tiltak.Deltaker
+import no.nav.amt.tiltak.core.domain.tiltak.DeltakerStatusInsert
+import no.nav.amt.tiltak.core.domain.tiltak.DeltakerUpsert
+import no.nav.amt.tiltak.core.domain.tiltak.NavEnhet
 import java.util.*
 
 interface DeltakerService {
@@ -27,18 +29,6 @@ interface DeltakerService {
 	fun finnesBruker(personIdent: String): Boolean
 
 	fun oppdaterAnsvarligVeileder(personIdent: String, navAnsattId: UUID)
-
-	fun leggTilOppstartsdato(deltakerId: UUID, arrangorAnsattId: UUID, oppstartsdato: LocalDate)
-
-	fun endreOppstartsdato(deltakerId: UUID, arrangorAnsattId: UUID, oppstartsdato: LocalDate)
-
-	fun forlengDeltakelse(deltakerId: UUID, arrangorAnsattId: UUID, sluttdato: LocalDate)
-
-	fun endreDeltakelsesprosent(deltakerId: UUID, arrangorAnsattId: UUID, deltakerProsent: Int, gyldigFraDato: LocalDate?)
-
-	fun avsluttDeltakelse(deltakerId: UUID, arrangorAnsattId: UUID, sluttdato: LocalDate, statusAarsak: DeltakerStatus.Aarsak)
-
-	fun deltakerIkkeAktuell(deltakerId: UUID, arrangorAnsattId: UUID, statusAarsak: DeltakerStatus.Aarsak)
 
 	fun erSkjermet(deltakerId: UUID): Boolean
 

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/EndringsmeldingService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/EndringsmeldingService.kt
@@ -34,5 +34,7 @@ interface EndringsmeldingService {
 	fun hentAktiveEndringsmeldingerForGjennomforing(gjennomforingId: UUID): List<Endringsmelding>
 
 	fun slett(deltakerId: UUID)
-
+	fun opprettTilbyPlassEndringsmelding(deltakerId: UUID, arrangorAnsattId: UUID)
+	fun opprettSettPaaVentelisteEndringsmelding(deltakerId: UUID, arrangorAnsattId: UUID)
+	fun opprettEndresluttdatoEndringsmelding(deltakerId: UUID, arrangorAnsattId: UUID, sluttdato: LocalDate)
 }

--- a/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/model/EndringsmeldingPublishDto.kt
+++ b/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/model/EndringsmeldingPublishDto.kt
@@ -15,7 +15,7 @@ data class EndringsmeldingPublishDto(
 	val utfortTidspunkt: LocalDateTime?,
 	val status: String,
 	val type: Type,
-	val innhold: Innhold,
+	val innhold: Innhold?,
 	val createdAt: LocalDateTime
 ) {
 	fun digest() = DigestUtils.md5DigestAsHex(JsonUtils.toJson(this).toByteArray())
@@ -28,6 +28,9 @@ enum class Type {
 	FORLENG_DELTAKELSE,
 	AVSLUTT_DELTAKELSE,
 	DELTAKER_IKKE_AKTUELL,
+	TILBY_PLASS,
+	SETT_PAA_VENTELISTE,
+	ENDRE_SLUTTDATO
 }
 
 data class DeltakerStatusAarsak(
@@ -62,14 +65,8 @@ sealed class Innhold {
 		val gyldigFraDato: LocalDate?
 	) : Innhold()
 
-	fun type(): Type {
-		return when (this) {
-			is LeggTilOppstartsdatoInnhold -> Type.LEGG_TIL_OPPSTARTSDATO
-			is EndreOppstartsdatoInnhold -> Type.ENDRE_OPPSTARTSDATO
-			is ForlengDeltakelseInnhold -> Type.FORLENG_DELTAKELSE
-			is AvsluttDeltakelseInnhold -> Type.AVSLUTT_DELTAKELSE
-			is DeltakerIkkeAktuellInnhold -> Type.DELTAKER_IKKE_AKTUELL
-			is EndreDeltakelseProsentInnhold -> Type.ENDRE_DELTAKELSE_PROSENT
-		}
-	}
+	data class EndreSluttdatoInnhold(
+		val sluttdato: LocalDate
+	) : Innhold()
+
 }

--- a/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/publish/EndringsmeldingPublishQuery.kt
+++ b/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/publish/EndringsmeldingPublishQuery.kt
@@ -44,7 +44,7 @@ class EndringsmeldingPublishQuery(
 		).first()
 	}
 
-	private fun parseInnholdJson(innholdJson: String, type: Type): Innhold {
+	private fun parseInnholdJson(innholdJson: String, type: Type): Innhold? {
 		return when (type) {
 			Type.LEGG_TIL_OPPSTARTSDATO ->
 				objectMapper.readValue<Innhold.LeggTilOppstartsdatoInnhold>(innholdJson)
@@ -63,6 +63,12 @@ class EndringsmeldingPublishQuery(
 
 			Type.ENDRE_DELTAKELSE_PROSENT ->
 				objectMapper.readValue<Innhold.EndreDeltakelseProsentInnhold>(innholdJson)
+			Type.ENDRE_SLUTTDATO ->	objectMapper.readValue<Innhold.EndreSluttdatoInnhold>(innholdJson)
+			Type.TILBY_PLASS,
+			Type.SETT_PAA_VENTELISTE -> null
+
+
+
 		}
 
 	}

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
@@ -1,21 +1,30 @@
 package no.nav.amt.tiltak.deltaker.service
 
-import no.nav.amt.tiltak.core.domain.tiltak.*
+import no.nav.amt.tiltak.core.domain.tiltak.Deltaker
+import no.nav.amt.tiltak.core.domain.tiltak.DeltakerStatus
+import no.nav.amt.tiltak.core.domain.tiltak.DeltakerStatusInsert
+import no.nav.amt.tiltak.core.domain.tiltak.DeltakerUpsert
+import no.nav.amt.tiltak.core.domain.tiltak.Gjennomforing
+import no.nav.amt.tiltak.core.domain.tiltak.NavEnhet
+import no.nav.amt.tiltak.core.domain.tiltak.harIkkeStartet
 import no.nav.amt.tiltak.core.kafka.KafkaProducerService
 import no.nav.amt.tiltak.core.port.BrukerService
 import no.nav.amt.tiltak.core.port.DeltakerService
 import no.nav.amt.tiltak.core.port.EndringsmeldingService
+import no.nav.amt.tiltak.core.port.GjennomforingService
 import no.nav.amt.tiltak.data_publisher.DataPublisherService
 import no.nav.amt.tiltak.data_publisher.model.DataPublishType
-import no.nav.amt.tiltak.core.port.GjennomforingService
-import no.nav.amt.tiltak.deltaker.dbo.*
+import no.nav.amt.tiltak.deltaker.dbo.DeltakerDbo
+import no.nav.amt.tiltak.deltaker.dbo.DeltakerInsertDbo
+import no.nav.amt.tiltak.deltaker.dbo.DeltakerStatusDbo
+import no.nav.amt.tiltak.deltaker.dbo.DeltakerStatusInsertDbo
+import no.nav.amt.tiltak.deltaker.dbo.DeltakerUpdateDbo
 import no.nav.amt.tiltak.deltaker.repositories.DeltakerRepository
 import no.nav.amt.tiltak.deltaker.repositories.DeltakerStatusRepository
 import no.nav.amt.tiltak.deltaker.repositories.SkjultDeltakerRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -259,46 +268,6 @@ open class DeltakerServiceImpl(
 
 	override fun oppdaterAnsvarligVeileder(personIdent: String, navAnsattId: UUID) {
 		brukerService.oppdaterAnsvarligVeileder(personIdent, navAnsattId)
-	}
-
-	override fun leggTilOppstartsdato(deltakerId: UUID, arrangorAnsattId: UUID, oppstartsdato: LocalDate) {
-		endringsmeldingService.opprettLeggTilOppstartsdatoEndringsmelding(deltakerId, arrangorAnsattId, oppstartsdato)
-		publisherService.publish(deltakerId, DataPublishType.DELTAKER)
-	}
-
-	override fun endreOppstartsdato(deltakerId: UUID, arrangorAnsattId: UUID, oppstartsdato: LocalDate) {
-		endringsmeldingService.opprettEndreOppstartsdatoEndringsmelding(deltakerId, arrangorAnsattId, oppstartsdato)
-		publisherService.publish(deltakerId, DataPublishType.DELTAKER)
-	}
-
-	override fun forlengDeltakelse(deltakerId: UUID, arrangorAnsattId: UUID, sluttdato: LocalDate) {
-		endringsmeldingService.opprettForlengDeltakelseEndringsmelding(deltakerId, arrangorAnsattId, sluttdato)
-		publisherService.publish(deltakerId, DataPublishType.DELTAKER)
-	}
-
-	override fun endreDeltakelsesprosent(deltakerId: UUID, arrangorAnsattId: UUID, deltakerProsent: Int, gyldigFraDato: LocalDate?) {
-		endringsmeldingService.opprettEndreDeltakelseProsentEndringsmelding(
-			deltakerId = deltakerId,
-			arrangorAnsattId = arrangorAnsattId,
-			deltakerProsent = deltakerProsent,
-			gyldigFraDato = gyldigFraDato
-		)
-		publisherService.publish(deltakerId, DataPublishType.DELTAKER)
-	}
-
-	override fun avsluttDeltakelse(
-		deltakerId: UUID,
-		arrangorAnsattId: UUID,
-		sluttdato: LocalDate,
-		statusAarsak: DeltakerStatus.Aarsak
-	) {
-		endringsmeldingService.opprettAvsluttDeltakelseEndringsmelding(deltakerId, arrangorAnsattId, sluttdato, statusAarsak)
-		publisherService.publish(deltakerId, DataPublishType.DELTAKER)
-	}
-
-	override fun deltakerIkkeAktuell(deltakerId: UUID, arrangorAnsattId: UUID, statusAarsak: DeltakerStatus.Aarsak) {
-		endringsmeldingService.opprettDeltakerIkkeAktuellEndringsmelding(deltakerId, arrangorAnsattId, statusAarsak)
-		publisherService.publish(deltakerId, DataPublishType.DELTAKER)
 	}
 
 	override fun hentDeltakerMap(deltakerIder: List<UUID>): Map<UUID, Deltaker> {

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingDbo.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingDbo.kt
@@ -14,7 +14,7 @@ data class EndringsmeldingDbo(
 	val opprettetAvArrangorAnsattId: UUID,
 	val status: Endringsmelding.Status,
 	val type: Type,
-	val innhold: Innhold,
+	val innhold: Innhold?,
 	val createdAt: ZonedDateTime,
 	val modifiedAt: ZonedDateTime
 ) {
@@ -26,6 +26,9 @@ data class EndringsmeldingDbo(
 		FORLENG_DELTAKELSE,
 		AVSLUTT_DELTAKELSE,
 		DELTAKER_IKKE_AKTUELL,
+		TILBY_PLASS,
+		SETT_PAA_VENTELISTE,
+		ENDRE_SLUTTDATO
 	}
 
 	data class DeltakerStatusAarsak(
@@ -60,15 +63,8 @@ data class EndringsmeldingDbo(
 			val gyldigFraDato: LocalDate?
 		): Innhold()
 
-		fun type(): Type {
-			return when(this) {
-				is LeggTilOppstartsdatoInnhold -> Type.LEGG_TIL_OPPSTARTSDATO
-				is EndreOppstartsdatoInnhold -> Type.ENDRE_OPPSTARTSDATO
-				is ForlengDeltakelseInnhold -> Type.FORLENG_DELTAKELSE
-				is AvsluttDeltakelseInnhold -> Type.AVSLUTT_DELTAKELSE
-				is DeltakerIkkeAktuellInnhold -> Type.DELTAKER_IKKE_AKTUELL
-				is EndreDeltakelseProsentInnhold -> Type.ENDRE_DELTAKELSE_PROSENT
-			}
-		}
+		data class EndreSluttdatoInnhold(
+			val sluttdato: LocalDate
+		) : Innhold()
 	}
 }

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingRepository.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingRepository.kt
@@ -132,7 +132,7 @@ open class EndringsmeldingRepository(
 	}
 
 
-	fun insert(id: UUID, deltakerId: UUID, opprettetAvArrangorAnsattId: UUID, innhold: EndringsmeldingDbo.Innhold) {
+	fun insert(id: UUID, deltakerId: UUID, opprettetAvArrangorAnsattId: UUID, type: EndringsmeldingDbo.Type, innhold: EndringsmeldingDbo.Innhold?) {
 		val sql = """
 			INSERT INTO endringsmelding(id, deltaker_id, opprettet_av_arrangor_ansatt_id, type, innhold, status)
 			VALUES(:id, :deltakerId, :opprettetAvArrangorAnsattId, :type, CAST(:innhold as jsonb), 'AKTIV')
@@ -142,8 +142,8 @@ open class EndringsmeldingRepository(
 			"id" to id,
 			"deltakerId" to deltakerId,
 			"opprettetAvArrangorAnsattId" to opprettetAvArrangorAnsattId,
-			"type" to innhold.type().name,
-			"innhold" to objectMapper.writeValueAsString(innhold),
+			"type" to type.name,
+			"innhold" to  objectMapper.writeValueAsString(innhold),
 		)
 		template.update(sql, params)
 	}
@@ -160,7 +160,7 @@ open class EndringsmeldingRepository(
 		template.update(sql, params)
 	}
 
-	private fun parseInnholdJson(innholdJson: String, type: EndringsmeldingDbo.Type): EndringsmeldingDbo.Innhold {
+	private fun parseInnholdJson(innholdJson: String, type: EndringsmeldingDbo.Type): EndringsmeldingDbo.Innhold? {
 		return when(type) {
 			EndringsmeldingDbo.Type.LEGG_TIL_OPPSTARTSDATO ->
 				objectMapper.readValue<EndringsmeldingDbo.Innhold.LeggTilOppstartsdatoInnhold>(innholdJson)
@@ -174,6 +174,11 @@ open class EndringsmeldingRepository(
 				objectMapper.readValue<EndringsmeldingDbo.Innhold.DeltakerIkkeAktuellInnhold>(innholdJson)
 			EndringsmeldingDbo.Type.ENDRE_DELTAKELSE_PROSENT ->
 				objectMapper.readValue<EndringsmeldingDbo.Innhold.EndreDeltakelseProsentInnhold>(innholdJson)
+			EndringsmeldingDbo.Type.ENDRE_SLUTTDATO ->
+				objectMapper.readValue<EndringsmeldingDbo.Innhold.EndreSluttdatoInnhold>(innholdJson)
+			EndringsmeldingDbo.Type.TILBY_PLASS,
+			EndringsmeldingDbo.Type.SETT_PAA_VENTELISTE -> null
+
 		}
 
 	}

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingServiceImpl.kt
@@ -87,6 +87,7 @@ open class EndringsmeldingServiceImpl(
 			deltakerId,
 			arrangorAnsattId,
 			innhold,
+			EndringsmeldingDbo.Type.LEGG_TIL_OPPSTARTSDATO
 		)
 	}
 
@@ -100,6 +101,7 @@ open class EndringsmeldingServiceImpl(
 			deltakerId,
 			arrangorAnsattId,
 			innhold,
+			EndringsmeldingDbo.Type.ENDRE_OPPSTARTSDATO
 		)
 	}
 
@@ -113,6 +115,7 @@ open class EndringsmeldingServiceImpl(
 			deltakerId,
 			arrangorAnsattId,
 			innhold,
+			EndringsmeldingDbo.Type.FORLENG_DELTAKELSE
 		)
 	}
 
@@ -130,7 +133,9 @@ open class EndringsmeldingServiceImpl(
 		opprettOgMarkerAktiveSomUtdatert(
 			deltakerId,
 			arrangorAnsattId,
-			innhold
+			innhold,
+			EndringsmeldingDbo.Type.ENDRE_DELTAKELSE_PROSENT
+
 		)
 	}
 
@@ -146,6 +151,8 @@ open class EndringsmeldingServiceImpl(
 			deltakerId,
 			arrangorAnsattId,
 			innhold,
+			EndringsmeldingDbo.Type.AVSLUTT_DELTAKELSE
+
 		)
 	}
 
@@ -160,6 +167,45 @@ open class EndringsmeldingServiceImpl(
 			deltakerId,
 			arrangorAnsattId,
 			innhold,
+			EndringsmeldingDbo.Type.DELTAKER_IKKE_AKTUELL
+		)
+	}
+
+	override fun opprettTilbyPlassEndringsmelding(
+		deltakerId: UUID,
+		arrangorAnsattId: UUID,
+	) {
+		opprettOgMarkerAktiveSomUtdatert(
+			deltakerId,
+			arrangorAnsattId,
+			null,
+			EndringsmeldingDbo.Type.TILBY_PLASS
+		)
+	}
+
+	override fun opprettSettPaaVentelisteEndringsmelding(
+		deltakerId: UUID,
+		arrangorAnsattId: UUID,
+	) {
+		opprettOgMarkerAktiveSomUtdatert(
+			deltakerId,
+			arrangorAnsattId,
+			null,
+			EndringsmeldingDbo.Type.SETT_PAA_VENTELISTE
+		)
+	}
+
+	override fun opprettEndresluttdatoEndringsmelding(
+		deltakerId: UUID,
+		arrangorAnsattId: UUID,
+		sluttdato: LocalDate
+	) {
+		val innhold = EndringsmeldingDbo.Innhold.EndreSluttdatoInnhold(sluttdato)
+		opprettOgMarkerAktiveSomUtdatert(
+			deltakerId,
+			arrangorAnsattId,
+			innhold,
+			EndringsmeldingDbo.Type.ENDRE_SLUTTDATO
 		)
 	}
 
@@ -176,46 +222,63 @@ open class EndringsmeldingServiceImpl(
 			utfortTidspunkt = utfortTidspunkt,
 			opprettetAvArrangorAnsattId = opprettetAvArrangorAnsattId,
 			status = status,
-			innhold = mapEndringsmeldingInnhold(innhold),
+			innhold = innhold?.toModel(),
 			opprettet = createdAt,
+			type = type.toModel()
 		)
 	}
 
-	private fun mapEndringsmeldingInnhold(innhold: EndringsmeldingDbo.Innhold): Endringsmelding.Innhold {
-		return when(innhold) {
+	private fun EndringsmeldingDbo.Type.toModel(): Endringsmelding.Type {
+		return when (this) {
+			EndringsmeldingDbo.Type.LEGG_TIL_OPPSTARTSDATO -> Endringsmelding.Type.LEGG_TIL_OPPSTARTSDATO
+			EndringsmeldingDbo.Type.ENDRE_OPPSTARTSDATO -> Endringsmelding.Type.ENDRE_OPPSTARTSDATO
+			EndringsmeldingDbo.Type.FORLENG_DELTAKELSE -> Endringsmelding.Type.FORLENG_DELTAKELSE
+			EndringsmeldingDbo.Type.AVSLUTT_DELTAKELSE -> Endringsmelding.Type.AVSLUTT_DELTAKELSE
+			EndringsmeldingDbo.Type.DELTAKER_IKKE_AKTUELL -> Endringsmelding.Type.DELTAKER_IKKE_AKTUELL
+			EndringsmeldingDbo.Type.ENDRE_DELTAKELSE_PROSENT -> Endringsmelding.Type.ENDRE_DELTAKELSE_PROSENT
+			EndringsmeldingDbo.Type.TILBY_PLASS -> Endringsmelding.Type.TILBY_PLASS
+			EndringsmeldingDbo.Type.SETT_PAA_VENTELISTE -> Endringsmelding.Type.SETT_PAA_VENTELISTE
+			EndringsmeldingDbo.Type.ENDRE_SLUTTDATO -> Endringsmelding.Type.ENDRE_SLUTTDATO
+		}
+	}
+
+	private fun EndringsmeldingDbo.Innhold.toModel(): Endringsmelding.Innhold {
+		return when(this) {
 			is EndringsmeldingDbo.Innhold.LeggTilOppstartsdatoInnhold ->
-				Endringsmelding.Innhold.LeggTilOppstartsdatoInnhold(innhold.oppstartsdato)
+				Endringsmelding.Innhold.LeggTilOppstartsdatoInnhold(this.oppstartsdato)
 			is EndringsmeldingDbo.Innhold.EndreOppstartsdatoInnhold ->
-				Endringsmelding.Innhold.EndreOppstartsdatoInnhold(innhold.oppstartsdato)
+				Endringsmelding.Innhold.EndreOppstartsdatoInnhold(this.oppstartsdato)
 			is EndringsmeldingDbo.Innhold.ForlengDeltakelseInnhold ->
-				Endringsmelding.Innhold.ForlengDeltakelseInnhold(innhold.sluttdato)
+				Endringsmelding.Innhold.ForlengDeltakelseInnhold(this.sluttdato)
 			is EndringsmeldingDbo.Innhold.AvsluttDeltakelseInnhold ->
 				Endringsmelding.Innhold.AvsluttDeltakelseInnhold(
-					innhold.sluttdato, DeltakerStatus.Aarsak(innhold.aarsak.type, innhold.aarsak.beskrivelse)
+					this.sluttdato, DeltakerStatus.Aarsak(this.aarsak.type, this.aarsak.beskrivelse)
 				)
 			is EndringsmeldingDbo.Innhold.DeltakerIkkeAktuellInnhold ->
 				Endringsmelding.Innhold.DeltakerIkkeAktuellInnhold(
-					DeltakerStatus.Aarsak(innhold.aarsak.type, innhold.aarsak.beskrivelse)
+					DeltakerStatus.Aarsak(this.aarsak.type, this.aarsak.beskrivelse)
 				)
 
 			is EndringsmeldingDbo.Innhold.EndreDeltakelseProsentInnhold ->
 				Endringsmelding.Innhold.EndreDeltakelseProsentInnhold(
-					deltakelseProsent = innhold.nyDeltakelseProsent,
-					gyldigFraDato = innhold.gyldigFraDato
+					deltakelseProsent = this.nyDeltakelseProsent,
+					gyldigFraDato = this.gyldigFraDato
 				)
+			is EndringsmeldingDbo.Innhold.EndreSluttdatoInnhold ->
+				Endringsmelding.Innhold.EndreSluttdatoInnhold(this.sluttdato)
 		}
 	}
 
 	private fun opprettOgMarkerAktiveSomUtdatert(
-		deltakerId: UUID, opprettetAvArrangorAnsattId: UUID, innhold: EndringsmeldingDbo.Innhold
+		deltakerId: UUID, opprettetAvArrangorAnsattId: UUID, innhold: EndringsmeldingDbo.Innhold?, type: EndringsmeldingDbo.Type
 	) {
 		val id = UUID.randomUUID()
 		transactionTemplate.executeWithoutResult {
-			endringsmeldingRepository.markerAktiveSomUtdatert(deltakerId, innhold.type())
-			endringsmeldingRepository.insert(id, deltakerId, opprettetAvArrangorAnsattId, innhold)
+			endringsmeldingRepository.markerAktiveSomUtdatert(deltakerId, type)
+			endringsmeldingRepository.insert(id, deltakerId, opprettetAvArrangorAnsattId, type, innhold)
 		}
 
-		log.info("Endringsmelding av type ${innhold.type().name} opprettet med id $id for deltaker $deltakerId")
+		log.info("Endringsmelding av type ${type.name} opprettet med id $id for deltaker $deltakerId")
 		publisherService.publish(id, DataPublishType.ENDRINGSMELDING)
 	}
 

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingRepositoryTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingRepositoryTest.kt
@@ -150,12 +150,32 @@ class EndringsmeldingRepositoryTest : FunSpec({
 			deltakerId = DELTAKER_1.id,
 			opprettetAvArrangorAnsattId = ARRANGOR_ANSATT_1.id,
 			innhold = innhold,
+			type = EndringsmeldingDbo.Type.LEGG_TIL_OPPSTARTSDATO
 		)
 
 		val endringsmelding = repository.get(id)
 
 		endringsmelding.type shouldBe EndringsmeldingDbo.Type.LEGG_TIL_OPPSTARTSDATO
 		endringsmelding.innhold shouldBe innhold
+		endringsmelding.status shouldBe Endringsmelding.Status.AKTIV
+	}
+
+	test("insert - skal inserte Tilby plass endringsmelding") {
+		val id = UUID.randomUUID()
+
+		repository.insert(
+			id = id,
+			deltakerId = DELTAKER_1.id,
+			opprettetAvArrangorAnsattId = ARRANGOR_ANSATT_1.id,
+			innhold = null,
+			type = EndringsmeldingDbo.Type.TILBY_PLASS
+
+		)
+
+		val endringsmelding = repository.get(id)
+
+		endringsmelding.type shouldBe EndringsmeldingDbo.Type.TILBY_PLASS
+		endringsmelding.innhold shouldBe null
 		endringsmelding.status shouldBe Endringsmelding.Status.AKTIV
 	}
 
@@ -168,6 +188,8 @@ class EndringsmeldingRepositoryTest : FunSpec({
 			deltakerId = DELTAKER_1.id,
 			opprettetAvArrangorAnsattId = ARRANGOR_ANSATT_1.id,
 			innhold = innhold,
+			type = EndringsmeldingDbo.Type.ENDRE_OPPSTARTSDATO
+
 		)
 
 		val endringsmelding = repository.get(id)
@@ -186,6 +208,8 @@ class EndringsmeldingRepositoryTest : FunSpec({
 			deltakerId = DELTAKER_1.id,
 			opprettetAvArrangorAnsattId = ARRANGOR_ANSATT_1.id,
 			innhold = innhold,
+			type = EndringsmeldingDbo.Type.FORLENG_DELTAKELSE
+
 		)
 
 		val endringsmelding = repository.get(id)
@@ -207,6 +231,8 @@ class EndringsmeldingRepositoryTest : FunSpec({
 			deltakerId = DELTAKER_1.id,
 			opprettetAvArrangorAnsattId = ARRANGOR_ANSATT_1.id,
 			innhold = innhold,
+			type = EndringsmeldingDbo.Type.AVSLUTT_DELTAKELSE
+
 		)
 
 		val endringsmelding = repository.get(id)
@@ -227,6 +253,8 @@ class EndringsmeldingRepositoryTest : FunSpec({
 			deltakerId = DELTAKER_1.id,
 			opprettetAvArrangorAnsattId = ARRANGOR_ANSATT_1.id,
 			innhold = innhold,
+			type = EndringsmeldingDbo.Type.DELTAKER_IKKE_AKTUELL
+
 		)
 
 		val endringsmelding = repository.get(id)


### PR DESCRIPTION
* Endrer så endringsmelding.type bruker enumverdi isteden for å utlede vha innholdet i meldingen
* Opprettelse av endringsmeldinger går ikke lengre igjennom DeltakerService da det ikke er nødvendig