### PR TITLE
Skip tester i codeql workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Build maven artifacts
-        run: mvn -B package
+        run: mvn -B package -DskipTests
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
         with:


### PR DESCRIPTION
Det virker unødvendig å kjøre testene her da vi har en egen workflow for det, og det gjør at denne workflowen tar veldig lang tid.