### PR TITLE
lager internt endepunkt for å slette endringsmeldinger

### DIFF
--- a/bff-internal/src/main/kotlin/no/nav/amt/tiltak/bff/internal/EndringsmeldingController.kt
+++ b/bff-internal/src/main/kotlin/no/nav/amt/tiltak/bff/internal/EndringsmeldingController.kt
@@ -1,0 +1,43 @@
+package no.nav.amt.tiltak.bff.internal
+
+import jakarta.servlet.http.HttpServletRequest
+import no.nav.amt.tiltak.core.port.EndringsmeldingService
+import no.nav.common.job.JobRunner
+import no.nav.security.token.support.core.api.Unprotected
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+@Unprotected
+@RestController
+@RequestMapping("/internal/api/endringsmelding")
+class EndringsmeldingController(
+	private val endringsmeldingService: EndringsmeldingService
+) {
+
+	@DeleteMapping("/er-aktuell")
+	fun republiserDeltakere(request: HttpServletRequest) {
+		if (isInternal(request)) {
+			JobRunner.runAsync("slett_em_aktuell", endringsmeldingService::slettErAktuell)
+		} else {
+			throw ResponseStatusException(HttpStatus.UNAUTHORIZED)
+		}
+	}
+
+	@DeleteMapping("/er-ikke-aktuell")
+	fun republiserDeltaker(request: HttpServletRequest) {
+		if (isInternal(request)) {
+			JobRunner.runAsync("slett_em_ikke_aktuell") { endringsmeldingService.slettErIkkeAktuellOppfyllerIkkeKravene() }
+		} else {
+			throw ResponseStatusException(HttpStatus.UNAUTHORIZED)
+		}
+	}
+
+	private fun isInternal(request: HttpServletRequest): Boolean {
+		return request.remoteAddr == "127.0.0.1"
+	}
+
+
+}

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/EndringsmeldingService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/EndringsmeldingService.kt
@@ -36,4 +36,8 @@ interface EndringsmeldingService {
 	fun slett(deltakerId: UUID)
 	fun opprettErAktuellEndringsmelding(deltakerId: UUID, arrangorAnsattId: UUID): UUID
 	fun opprettEndresluttdatoEndringsmelding(deltakerId: UUID, arrangorAnsattId: UUID, sluttdato: LocalDate): UUID
+
+	fun slettErAktuell()
+
+	fun slettErIkkeAktuellOppfyllerIkkeKravene()
 }

--- a/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/DataPublisherService.kt
+++ b/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/DataPublisherService.kt
@@ -136,8 +136,14 @@ class DataPublisherService(
 	}
 
 	private fun publishEndringsmelding(id: UUID, forcePublish: Boolean = false) {
-
 		val currentData = EndringsmeldingPublishQuery(template).get(id)
+
+		if (currentData == null) {
+			val record = ProducerRecord<String, String?>(kafkaTopicProperties.amtEndringsmeldingTopic, id.toString(), null)
+			stringKafkaProducer.sendSync(record)
+			logger.info("Legger inn tombstone på ENDRINGSMELDING med id $id")
+			return
+		}
 
 		if (forcePublish || !publishRepository.hasHash(id, DataPublishType.ENDRINGSMELDING, currentData.digest())) {
 			val key = id.toString()

--- a/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/publish/EndringsmeldingPublishQuery.kt
+++ b/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/publish/EndringsmeldingPublishQuery.kt
@@ -12,7 +12,7 @@ import no.nav.amt.tiltak.data_publisher.model.Innhold
 import no.nav.amt.tiltak.data_publisher.model.Type
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import java.util.*
+import java.util.UUID
 
 class EndringsmeldingPublishQuery(
 	private val template: NamedParameterJdbcTemplate
@@ -36,12 +36,12 @@ class EndringsmeldingPublishQuery(
 		)
 	}
 
-	fun get(id: UUID): EndringsmeldingPublishDto {
+	fun get(id: UUID): EndringsmeldingPublishDto? {
 		return template.query(
 			"SELECT * FROM endringsmelding WHERE id = :id",
 			sqlParameters("id" to id),
 			rowMapper
-		).first()
+		).firstOrNull()
 	}
 
 	private fun parseInnholdJson(innholdJson: String, type: Type): Innhold? {

--- a/data-publisher/src/test/kotlin/no/nav/amt/tiltak/data_publisher/publish/EndringsmeldingQueryTest.kt
+++ b/data-publisher/src/test/kotlin/no/nav/amt/tiltak/data_publisher/publish/EndringsmeldingQueryTest.kt
@@ -26,7 +26,7 @@ class EndringsmeldingQueryTest: FunSpec({
 		val input = db.createEndringsmelding()
 		val data = query.get(input.id)
 
-		data.id shouldBe input.id
+		data?.id shouldBe input.id
 	}
 
 })

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/endringsmelding/EndringsmeldingServiceImpl.kt
@@ -198,7 +198,27 @@ open class EndringsmeldingServiceImpl(
 	}
 
 	override fun slett(deltakerId: UUID) {
+		val endringsmeldinger = endringsmeldingRepository.getByDeltaker(deltakerId)
 		endringsmeldingRepository.deleteByDeltaker(deltakerId)
+		endringsmeldinger.forEach {
+			publisherService.publish(it.id, DataPublishType.ENDRINGSMELDING)
+		}
+	}
+
+	override fun slettErAktuell() {
+		val slettedeEndringsmeldinger = endringsmeldingRepository.deleteErAktuell()
+		slettedeEndringsmeldinger.forEach {
+			publisherService.publish(it.id, DataPublishType.ENDRINGSMELDING)
+		}
+		log.info("Slettet ${slettedeEndringsmeldinger.size} er aktuell-meldinger")
+	}
+
+	override fun slettErIkkeAktuellOppfyllerIkkeKravene() {
+		val slettedeEndringsmeldinger = endringsmeldingRepository.deleteErIkkeAktuellOppfyllerIkkeKravene()
+		slettedeEndringsmeldinger.forEach {
+			publisherService.publish(it.id, DataPublishType.ENDRINGSMELDING)
+		}
+		log.info("Slettet ${slettedeEndringsmeldinger.size} er ikke aktuell-meldinger med årsaktype OPPFYLLER_IKKE_KRAVENE")
 	}
 
 


### PR DESCRIPTION
https://trello.com/c/0gc9U6Cn/1096-rydde-opp-i-kode-slette-tidligere-endringsmelding-er-aktuell

Jeg har også lagt inn støtte for at vi tombstoner endringsmeldinger når de slettes, det manglet visst. BFF-en støtter tombstone på denne topicen allerede og jeg tror ikke det er noen andre konsumenter. 