### PR TITLE
Springcontext versjon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,6 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
-                <version>6.0.13</version>
             </dependency>
 
             <dependency>

--- a/tilgangskontroll-tiltaksansvarlig/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksansvarlig/TiltaksansvarligGjennomforingTilgangRepositoryTest.kt
+++ b/tilgangskontroll-tiltaksansvarlig/src/test/kotlin/no/nav/amt/tiltak/tilgangskontroll_tiltaksansvarlig/TiltaksansvarligGjennomforingTilgangRepositoryTest.kt
@@ -17,7 +17,7 @@ import no.nav.amt.tiltak.test.database.data.inputs.TiltaksansvarligGjennomforing
 import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.time.ZonedDateTime
-import java.util.*
+import java.util.UUID
 
 
 class TiltaksansvarligGjennomforingTilgangRepositoryTest : FunSpec({
@@ -102,7 +102,7 @@ class TiltaksansvarligGjennomforingTilgangRepositoryTest : FunSpec({
 
 		val tilgang = repository.hentTilgang(id)
 
-		tilgang.gyldigTil shouldBeBefore ZonedDateTime.now()
+		tilgang.gyldigTil shouldBeBefore ZonedDateTime.now().plusSeconds(1)
 	}
 
 })


### PR DESCRIPTION
Det lønner seg ofte å la spring boot styre versjoner av en del spring-nære dependencies (f.eks. spring-context) for å sikre at man får versjoner som er kompatible med hverandre. Det er jo det som opprinnelig var hensikten med spring boot :)

Den andre endringen er for å fikse et presisjonsproblem mellom postgres-dockercontaineren sin current timestamp og `ZonedDateTime.now()`. 