### PR TITLE
Nye statuser

### DIFF
--- a/.docs/deltaker-v1.md
+++ b/.docs/deltaker-v1.md
@@ -75,11 +75,11 @@ Kilden til dataene om deltakerene er i hovedsak Arena per dags dato. I fremtiden
 
 #### Status
 
-|Felt|Format|Beskrivelse|
-|-|-|-|
-|**type**|`string`|En av følgende verdier: `VENTER_PA_OPPSTART`, `DELTAR`, `HAR_SLUTTET`, `IKKE_AKTUELL`, `FEILREGISTRERT`, `SOKT_INN`, `VURDERES`, `VENTELISTE`, `AVBRUTT`, `FULLFORT`, `PABEGYNT_REGISTRERING` <br /><br /> Det er litt ulike typer statuser som kan settes på deltakere, basert på hvilke tiltak de deltar på. Hovedregelen er at `FULLFORT` og `AVBRUTT` kan kun settes på deltakere som går på tiltak hvor det er en felles oppstart, typisk kurs som `JOBBK`, `GRUPPEAMO`, `GRUFAGYRKE`, mens `HAR_SLUTTET` brukes kun på de andre tiltakene som har et "løpende" inntak og oppstart av deltakere.|
-|**aarsak**|`string\|null`|En årsak kan finnes på enkelte typer statuser (`HAR_SLUTTET`, `IKKE_AKTUELL` og `AVBRUTT`) og er en av følgende verdier: `SYK`, `FATT_JOBB`, `TRENGER_ANNEN_STOTTE`, `FIKK_IKKE_PLASS`, `IKKE_MOTT`, `ANNET`, `AVLYST_KONTRAKT`|
-|**opprettetDato**|`datetime`|Tidsstempel for når statusen ble opprettet|
+|Felt|Format| Beskrivelse                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|-|-|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|**type**|`string`| En av følgende verdier: `VENTER_PA_OPPSTART`, `DELTAR`, `HAR_SLUTTET`, `IKKE_AKTUELL`, `FEILREGISTRERT`, `SOKT_INN`, `VURDERES`, `VENTELISTE`, `AVBRUTT`, `FULLFORT`, `PABEGYNT_REGISTRERING`, `UTKAST_TIL_PAMELDING`, `AVBRUTT_UTKAST` <br /><br /> Det er litt ulike typer statuser som kan settes på deltakere, basert på hvilke tiltak de deltar på. Hovedregelen er at `FULLFORT` og `AVBRUTT` kan kun settes på deltakere som går på tiltak hvor det er en felles oppstart, typisk kurs som `JOBBK`, `GRUPPEAMO`, `GRUFAGYRKE`, mens `HAR_SLUTTET` brukes kun på de andre tiltakene som har et "løpende" inntak og oppstart av deltakere. |
+|**aarsak**|`string\|null`| En årsak kan finnes på enkelte typer statuser (`HAR_SLUTTET`, `IKKE_AKTUELL`, `AVBRUTT` og `AVBRUTT_UTKAST`) og er en av følgende verdier: `SYK`, `FATT_JOBB`, `TRENGER_ANNEN_STOTTE`, `FIKK_IKKE_PLASS`, `IKKE_MOTT`, `ANNET`, `AVLYST_KONTRAKT`                                                                                                                                                                                                                                                                                                                                                                                               |
+|**opprettetDato**|`datetime`| Tidsstempel for når statusen ble opprettet                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 For mer informasjon om når og hvordan deltakerstatuser settes og endres se mer utdypende dokumentasjon på [Confluence](https://confluence.adeo.no/pages/viewpage.action?pageId=573710206).
 
@@ -116,6 +116,7 @@ data class DeltakerStatusDto(
     }
 
     enum class Type {
+        UTKAST_TIL_PAMELDING, AVBRUTT_UTKAST,
         VENTER_PA_OPPSTART, DELTAR, HAR_SLUTTET, IKKE_AKTUELL, FEILREGISTRERT,
         SOKT_INN, VURDERES, VENTELISTE, AVBRUTT, FULLFORT, 
         PABEGYNT_REGISTRERING, 

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/DeltakerStatus.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/DeltakerStatus.kt
@@ -16,6 +16,7 @@ data class DeltakerStatus(
 	}
 
 	enum class Type {
+		UTKAST_TIL_PAMELDING, AVBRUTT_UTKAST, // nye statuser for påmelding utenfor Arena
 		VENTER_PA_OPPSTART, DELTAR, HAR_SLUTTET, IKKE_AKTUELL, FEILREGISTRERT,
 		SOKT_INN, VURDERES, VENTELISTE, AVBRUTT, FULLFORT, // kurs statuser
 		PABEGYNT_REGISTRERING, PABEGYNT, //PABEGYNT er erstattet av PABEGYNT_REGISTRERING, men må beholdes så lenge statusen er på topicen
@@ -28,14 +29,16 @@ val AVSLUTTENDE_STATUSER = listOf(
 	DeltakerStatus.Type.IKKE_AKTUELL,
 	DeltakerStatus.Type.FEILREGISTRERT,
 	DeltakerStatus.Type.AVBRUTT,
-	DeltakerStatus.Type.FULLFORT
+	DeltakerStatus.Type.FULLFORT,
+	DeltakerStatus.Type.AVBRUTT_UTKAST
 )
 
 val VENTER_PAA_PLASS_STATUSER = listOf(
 	DeltakerStatus.Type.SOKT_INN,
 	DeltakerStatus.Type.VURDERES,
 	DeltakerStatus.Type.VENTELISTE,
-	DeltakerStatus.Type.PABEGYNT_REGISTRERING
+	DeltakerStatus.Type.PABEGYNT_REGISTRERING,
+	DeltakerStatus.Type.UTKAST_TIL_PAMELDING
 )
 
 val STATUSER_SOM_KAN_SKJULES = listOf(

--- a/external-api/src/main/kotlin/no/nav/amt/tiltak/external/api/dto/StatusDto.kt
+++ b/external-api/src/main/kotlin/no/nav/amt/tiltak/external/api/dto/StatusDto.kt
@@ -3,6 +3,7 @@ package no.nav.amt.tiltak.external.api.dto
 import no.nav.amt.tiltak.core.domain.tiltak.DeltakerStatus
 
 enum class DeltakerStatusDto {
+	UTKAST_TIL_PAMELDING, AVBRUTT_UTKAST,
 	VENTER_PA_OPPSTART, DELTAR, HAR_SLUTTET, FULLFORT, IKKE_AKTUELL, FEILREGISTRERT,
 	SOKT_INN, VURDERES, VENTELISTE, AVBRUTT, PABEGYNT_REGISTRERING
 }


### PR DESCRIPTION
Nye statuser ifm ny påmeldingsløsning. Litt tidlig kanskje siden amt-tiltak ikke lytter på deltakere fra ny påmelding ennå, men da er de hvertfall lagt inn. 

Jeg har valgt å behandle UTKAST_TIL_PAMELDING likt som PABEGYNT_REGISTRERING og AVBRUTT_UTKAST likt som FEILREGISTRERT. Det kan hende vi vil gjøre noen endringer på dette etterhvert. 