### PR TITLE
Sett endretDato manuelt på deltaker-v1

### DIFF
--- a/bff-internal/src/main/kotlin/no/nav/amt/tiltak/bff/internal/RepubliseringController.kt
+++ b/bff-internal/src/main/kotlin/no/nav/amt/tiltak/bff/internal/RepubliseringController.kt
@@ -38,7 +38,7 @@ class RepubliseringController(
 		request: HttpServletRequest,
 	) {
 		if (isInternal(request)) {
-			JobRunner.runAsync("republiser_deltaker_kafka") { deltakerService.publiserDeltakerPaKafka(id) }
+			JobRunner.runAsync("republiser_deltaker_kafka") { deltakerService.republiserDeltakerPaKafka(id) }
 		} else {
 			throw ResponseStatusException(HttpStatus.UNAUTHORIZED)
 		}

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/kafka/KafkaProducerService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/kafka/KafkaProducerService.kt
@@ -1,11 +1,12 @@
 package no.nav.amt.tiltak.core.kafka
 
 import no.nav.amt.tiltak.core.domain.tiltak.Deltaker
+import java.time.LocalDateTime
 import java.util.*
 
 interface KafkaProducerService {
 
-	fun publiserDeltaker(deltaker: Deltaker)
+	fun publiserDeltaker(deltaker: Deltaker, endretDato: LocalDateTime)
 
 	fun publiserSlettDeltaker(deltakerId: UUID)
 

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/DeltakerService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/DeltakerService.kt
@@ -5,6 +5,7 @@ import no.nav.amt.tiltak.core.domain.tiltak.DeltakerStatusInsert
 import no.nav.amt.tiltak.core.domain.tiltak.DeltakerUpsert
 import no.nav.amt.tiltak.core.domain.tiltak.Vurdering
 import no.nav.amt.tiltak.core.domain.tiltak.Vurderingstype
+import java.time.LocalDateTime
 import java.util.UUID
 
 interface DeltakerService {
@@ -41,7 +42,9 @@ interface DeltakerService {
 
 	fun republiserAlleDeltakerePaKafka(batchSize: Int = 500)
 
-	fun publiserDeltakerPaKafka(deltakerId: UUID)
+	fun republiserDeltakerPaKafka(deltakerId: UUID)
+
+	fun publiserDeltakerPaKafka(deltakerId: UUID, endretDato: LocalDateTime)
 
 	fun publiserDeltakerPaDeltakerV2Kafka(deltakerId: UUID)
 

--- a/kafka/kafka-producer/src/main/kotlin/no/nav/amt/tiltak/kafka/producer/KafkaProducerServiceImpl.kt
+++ b/kafka/kafka-producer/src/main/kotlin/no/nav/amt/tiltak/kafka/producer/KafkaProducerServiceImpl.kt
@@ -9,6 +9,7 @@ import no.nav.amt.tiltak.kafka.producer.dto.toDto
 import no.nav.common.kafka.producer.KafkaProducerClient
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 import java.util.*
 
 @Service
@@ -17,7 +18,7 @@ open class KafkaProducerServiceImpl(
 	private val kafkaProducerClient: KafkaProducerClient<ByteArray, ByteArray>
 ) : KafkaProducerService {
 
-	override fun publiserDeltaker(deltaker: Deltaker) {
+	override fun publiserDeltaker(deltaker: Deltaker, endretDato: LocalDateTime) {
 		val deltakerDto = DeltakerV1Dto(
 			id = deltaker.id,
 			gjennomforingId = deltaker.gjennomforingId,
@@ -28,7 +29,7 @@ open class KafkaProducerServiceImpl(
 			registrertDato = deltaker.registrertDato,
 			dagerPerUke = deltaker.dagerPerUke,
 			prosentStilling = deltaker.prosentStilling,
-			endretDato = deltaker.endretDato
+			endretDato = endretDato,
 		)
 
 		val key = deltaker.id.toString().toByteArray()

--- a/kafka/nav-bruker-ingestor/src/main/kotlin/no/nav/amt/tiltak/kafka/nav_bruker_ingestor/NavBrukerIngestorImpl.kt
+++ b/kafka/nav-bruker-ingestor/src/main/kotlin/no/nav/amt/tiltak/kafka/nav_bruker_ingestor/NavBrukerIngestorImpl.kt
@@ -9,6 +9,7 @@ import no.nav.amt.tiltak.core.port.NavAnsattService
 import no.nav.amt.tiltak.core.port.NavEnhetService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Service
@@ -17,7 +18,7 @@ class NavBrukerIngestorImpl(
 	val navEnhetService: NavEnhetService,
 	val deltakerService: DeltakerService,
 	val navAnsattService: NavAnsattService,
-): NavBrukerIngestor {
+) : NavBrukerIngestor {
 
 	private val log = LoggerFactory.getLogger(javaClass)
 
@@ -39,7 +40,12 @@ class NavBrukerIngestorImpl(
 		// av deltaker og bruker så kan det skje, og da hender det at denne skriver utdatert deltakerdata til topic.
 		// Det er kun endring i personident som skal trigge oppdatering på både deltaker-v1 og deltaker-v2
 		if (lagretBruker != null && lagretBruker.personIdent != brukerDto.personident) {
-			deltakere.forEach { deltakerService.publiserDeltakerPaKafka(it.id) }
+			deltakere.forEach {
+				deltakerService.publiserDeltakerPaKafka(
+					deltakerId = it.id,
+					endretDato = LocalDateTime.now(),
+				)
+			}
 		} else if (harEndredePersonopplysninger(lagretBruker, brukerDto)) {
 			deltakere.forEach { deltakerService.publiserDeltakerPaDeltakerV2Kafka(it.id) }
 		}

--- a/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/kafka/KafkaProducerServiceImplIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/kafka/KafkaProducerServiceImplIntegrationTest.kt
@@ -30,7 +30,8 @@ class KafkaProducerServiceImplIntegrationTest : IntegrationTestBase() {
 
 	@Test
 	fun `skal publisere deltaker med riktig key og value`() {
-		kafkaProducerService.publiserDeltaker(deltakerService.hentDeltaker(DELTAKER_1.id)!!)
+		val deltaker = deltakerService.hentDeltaker(DELTAKER_1.id)!!
+		kafkaProducerService.publiserDeltaker(deltaker, deltaker.endretDato)
 
 		val expectedJson = """
 			{"id":"dc600c70-124f-4fe7-a687-b58439beb214","gjennomforingId":"b3420940-5479-48c8-b2fa-3751c7a33aa2","personIdent":"12345678910","startDato":"2022-02-13","sluttDato":"2030-02-14","status":{"type":"DELTAR","aarsak":null,"opprettetDato":"2022-02-13T00:00:00"},"registrertDato":"2022-02-13T12:12:00","dagerPerUke":2.5,"prosentStilling":100.0,"endretDato":"2022-02-13T12:12:00"}

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImplTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImplTest.kt
@@ -259,18 +259,18 @@ class DeltakerServiceImplTest {
 		nyDeltaker!!.id shouldBe deltaker.id
 		nyDeltaker.gjennomforingId shouldBe deltaker.gjennomforingId
 
-		verify(exactly = 1) { kafkaProducerService.publiserDeltaker(any()) }
+		verify(exactly = 1) { kafkaProducerService.publiserDeltaker(any(), any()) }
 		verify(exactly = 1) { publisherService.publish(deltaker.id, DataPublishType.DELTAKER) }
 	}
 
 	@Test
 	fun `upsertDeltaker - republiserer ikke uendrede deltakere`() {
-		verify(exactly = 0) { kafkaProducerService.publiserDeltaker(any()) }
+		verify(exactly = 0) { kafkaProducerService.publiserDeltaker(any(), any()) }
 
 		deltakerServiceImpl.upsertDeltaker(BRUKER_1.personIdent, deltaker)
 		deltakerServiceImpl.upsertDeltaker(BRUKER_1.personIdent, deltaker)
 
-		verify(exactly = 1) { kafkaProducerService.publiserDeltaker(any()) }
+		verify(exactly = 1) { kafkaProducerService.publiserDeltaker(any(), any()) }
 		verify(exactly = 1) { publisherService.publish(deltaker.id, DataPublishType.DELTAKER) }
 	}
 
@@ -287,7 +287,7 @@ class DeltakerServiceImplTest {
 		nyDeltaker.gjennomforingId shouldBe deltaker.gjennomforingId
 		nyDeltaker.dagerPerUke shouldBe dagerPerUke
 
-		verify(exactly = 2) { kafkaProducerService.publiserDeltaker(any()) }
+		verify(exactly = 2) { kafkaProducerService.publiserDeltaker(any(), any()) }
 		verify(exactly = 2) { publisherService.publish(deltaker.id, DataPublishType.DELTAKER) }
 	}
 
@@ -305,7 +305,7 @@ class DeltakerServiceImplTest {
 			)
 		)
 
-		verify(exactly = 1) { kafkaProducerService.publiserDeltaker(any()) }
+		verify(exactly = 1) { kafkaProducerService.publiserDeltaker(any(), any()) }
 		verify(exactly = 1) { publisherService.publish(DELTAKER_1.id, DataPublishType.DELTAKER) }
 	}
 
@@ -339,7 +339,7 @@ class DeltakerServiceImplTest {
 			opprettetDato = now,
 			aktiv = true
 		)
-		verify(exactly = 2) { kafkaProducerService.publiserDeltaker(any()) }
+		verify(exactly = 2) { kafkaProducerService.publiserDeltaker(any(), any()) }
 		verify(exactly = 2) { publisherService.publish(nyDeltaker.id, DataPublishType.DELTAKER) }
 	}
 
@@ -367,7 +367,7 @@ class DeltakerServiceImplTest {
 		val status2 = deltakerStatusRepository.getStatusForDeltaker(nyDeltaker.id)
 
 		status2 shouldBe status1
-		verify(exactly = 2) { kafkaProducerService.publiserDeltaker(any()) }
+		verify(exactly = 2) { kafkaProducerService.publiserDeltaker(any(), any()) }
 		verify(exactly = 2) { publisherService.publish(nyDeltaker.id, DataPublishType.DELTAKER) }
 	}
 
@@ -403,7 +403,7 @@ class DeltakerServiceImplTest {
 		statuser.first().aktiv shouldBe false
 		statuser.first().type shouldBe statusInsertDbo.type
 		statuser.last().aktiv shouldBe true
-		verify(exactly = 2) { kafkaProducerService.publiserDeltaker(any()) }
+		verify(exactly = 2) { kafkaProducerService.publiserDeltaker(any(), any()) }
 		verify(exactly = 2) { publisherService.publish(nyDeltaker.id, DataPublishType.DELTAKER) }
 	}
 
@@ -524,7 +524,7 @@ class DeltakerServiceImplTest {
 		deltakerServiceImpl.skjulDeltakerForTiltaksarrangor(deltakerId, ARRANGOR_ANSATT_1.id)
 
 		deltakerServiceImpl.erSkjultForTiltaksarrangor(deltakerId) shouldBe true
-		verify(exactly = 0) { kafkaProducerService.publiserDeltaker(any()) }
+		verify(exactly = 0) { kafkaProducerService.publiserDeltaker(any(), any()) }
 		verify(exactly = 1) { publisherService.publish(deltakerId, DataPublishType.DELTAKER) }
 	}
 
@@ -552,7 +552,7 @@ class DeltakerServiceImplTest {
 
 		deltakerServiceImpl.republiserAlleDeltakerePaKafka(1)
 
-		verify(exactly = 2) { kafkaProducerService.publiserDeltaker(any()) }
+		verify(exactly = 2) { kafkaProducerService.publiserDeltaker(any(), any()) }
 		verify(exactly = 2) { publisherService.publish(any(), DataPublishType.DELTAKER) }
 	}
 
@@ -607,7 +607,7 @@ class DeltakerServiceImplTest {
 		lagretVurdering.opprettetAvArrangorAnsattId shouldBe ARRANGOR_ANSATT_1.id
 		lagretVurdering.gyldigFra shouldBeEqualTo LocalDateTime.now()
 		lagretVurdering.gyldigTil shouldBe null
-		verify(exactly = 0) { kafkaProducerService.publiserDeltaker(any()) }
+		verify(exactly = 0) { kafkaProducerService.publiserDeltaker(any(), any()) }
 		verify(exactly = 1) { publisherService.publish(deltakerId, DataPublishType.DELTAKER) }
 	}
 


### PR DESCRIPTION
For at denne datoen skal øke logisk for hver endring så kan vi ikke bruke `deltaker.endretDato` for den reflekterer kun endringer i deltakerrelasjonen. Så for at vi skal få en ny `endretDato` når kun status eller personident endres, så må vi enten oppdatere deltakerrelasjonen for å sette en ny `modified_at` eller sette datoen manuelt slik. Usikker på hvilken som er beste løsning, men dette sparer en del ekstra databasekall, og ved å ikke oppdatere `modified_at` så er det litt lettere å se når deltakerrelasjonen faktisk sist var oppdatert.