### PR TITLE
oppdaterer deltakerstatuser hvis gjennomføring endrer inntaksform

### DIFF
--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/DeltakerService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/DeltakerService.kt
@@ -51,4 +51,6 @@ interface DeltakerService {
 	fun slettDeltakerePaaGjennomforing(gjennomforingId: UUID)
 
 	fun lagreVurdering(deltakerId: UUID, arrangorAnsattId: UUID, vurderingstype: Vurderingstype, begrunnelse: String?): List<Vurdering>
+
+	fun konverterStatuserForDeltakerePaaGjennomforing(gjennomforingId: UUID, oppdatertGjennomforingErKurs: Boolean)
 }

--- a/data-publisher/src/test/kotlin/no/nav/amt/tiltak/data_publisher/DatabaseTestDataHandler.kt
+++ b/data-publisher/src/test/kotlin/no/nav/amt/tiltak/data_publisher/DatabaseTestDataHandler.kt
@@ -106,6 +106,7 @@ class DatabaseTestDataHandler(template: NamedParameterJdbcTemplate) {
 		deltakerId = deltakerId,
 		gyldigFra = LocalDateTime.now(),
 		status = DeltakerStatus.Type.DELTAR.name,
+		aarsak = null,
 		aktiv = true,
 		createdAt = ZonedDateTime.now()
 	)

--- a/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/TestData.kt
+++ b/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/TestData.kt
@@ -55,6 +55,7 @@ object TestData {
 		gyldigFra = LocalDateTime.now(),
 		status = "DELTAR",
 		aktiv = true,
+		aarsak = null,
 		createdAt = deltaker.createdAt
 	)
 
@@ -310,6 +311,7 @@ object TestData {
 		deltakerId = DELTAKER_1.id,
 		gyldigFra = LocalDateTime.now(),
 		status = "DELTAR",
+		aarsak = null,
 		aktiv = true
 	)
 
@@ -318,6 +320,7 @@ object TestData {
 		deltakerId = DELTAKER_1.id,
 		gyldigFra = LocalDateTime.now(),
 		status = DeltakerStatus.Type.VENTER_PA_OPPSTART.name,
+		aarsak = null,
 		aktiv = true
 	)
 
@@ -361,6 +364,7 @@ object TestData {
 		deltakerId = DELTAKER_2.id,
 		gyldigFra = LocalDateTime.now(),
 		status = "DELTAR",
+		aarsak = null,
 		aktiv = true
 	)
 
@@ -415,6 +419,7 @@ object TestData {
 		deltakerId = DELTAKER_4.id,
 		gyldigFra = LocalDateTime.now(),
 		status = "VENTER_PA_OPPSTART",
+		aarsak = null,
 		aktiv = true
 	)
 

--- a/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/TestDataRepository.kt
+++ b/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/TestDataRepository.kt
@@ -207,8 +207,8 @@ class TestDataRepository(
 
 	fun insertDeltakerStatus(cmd: DeltakerStatusInput) {
 		val sql = """
-			INSERT INTO deltaker_status (id, deltaker_id, gyldig_fra, status, aktiv, created_at)
-			VALUES (:id, :deltaker_id, :gyldigFra, :status, :aktiv, :createdAt)
+			INSERT INTO deltaker_status (id, deltaker_id, gyldig_fra, status, aarsak, aktiv, created_at)
+			VALUES (:id, :deltaker_id, :gyldigFra, :status, :aarsak, :aktiv, :createdAt)
 		""".trimIndent()
 
 		template.update(
@@ -217,6 +217,7 @@ class TestDataRepository(
 				"deltaker_id" to cmd.deltakerId,
 				"gyldigFra" to cmd.gyldigFra,
 				"status" to cmd.status,
+				"aarsak" to cmd.aarsak,
 				"aktiv" to cmd.aktiv,
 				"createdAt" to cmd.createdAt.toLocalDateTime()
 			)

--- a/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/inputs/DeltakerStatusInput.kt
+++ b/test/database/src/main/kotlin/no/nav/amt/tiltak/test/database/data/inputs/DeltakerStatusInput.kt
@@ -3,13 +3,14 @@ package no.nav.amt.tiltak.test.database.data.inputs
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
-import java.util.*
+import java.util.UUID
 
 data class DeltakerStatusInput(
 	val id: UUID,
 	val deltakerId: UUID,
 	val gyldigFra: LocalDateTime,
 	val status: String,
+	val aarsak: String?,
 	val aktiv: Boolean,
 	val createdAt: ZonedDateTime = ZonedDateTime.of(2022, 2, 13, 0, 0, 0, 0, ZoneId.systemDefault())
 )

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
@@ -231,9 +231,7 @@ open class DeltakerServiceImpl(
 	}
 
 	private fun getDeltakerStatusType(deltakerSluttdato: LocalDate?, gjennomforingSluttdato: LocalDate?): DeltakerStatus.Type {
-		return if (gjennomforingSluttdato == null) {
-			DeltakerStatus.Type.AVBRUTT
-		} else if (deltakerSluttdato == null) {
+		return if (gjennomforingSluttdato == null || deltakerSluttdato == null) {
 			DeltakerStatus.Type.FULLFORT
 		} else if (deltakerSluttdato.isBefore(gjennomforingSluttdato)) {
 			DeltakerStatus.Type.AVBRUTT

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
@@ -28,6 +28,7 @@ import no.nav.amt.tiltak.deltaker.repositories.VurderingRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -170,6 +171,75 @@ open class DeltakerServiceImpl(
 
 		publisherService.publish(deltakerId, DataPublishType.DELTAKER)
 		return vurderingRepository.getVurderingerForDeltaker(deltakerId)
+	}
+
+	override fun konverterStatuserForDeltakerePaaGjennomforing(
+		gjennomforingId: UUID,
+		oppdatertGjennomforingErKurs: Boolean
+	) {
+		val deltakere = hentDeltakerePaaGjennomforing(gjennomforingId)
+		if (deltakere.isNotEmpty()) {
+			if (oppdatertGjennomforingErKurs) {
+				konverterDeltakerstatuseFraLopendeInntakTilKurs(deltakere, gjennomforingId)
+			} else {
+				konverterDeltakerstatuseFraKursTilLopendeInntak(deltakere)
+			}
+		}
+	}
+
+	private fun konverterDeltakerstatuseFraKursTilLopendeInntak(deltakere: List<Deltaker>) {
+		val deltakereSomSkalOppdateres =
+			deltakere.filter { it.status.type == DeltakerStatus.Type.AVBRUTT || it.status.type == DeltakerStatus.Type.FULLFORT }
+
+		deltakereSomSkalOppdateres.forEach {
+			insertStatus(
+				DeltakerStatusInsert(
+					id = UUID.randomUUID(),
+					deltakerId = it.id,
+					type = DeltakerStatus.Type.HAR_SLUTTET,
+					aarsak = it.status.aarsak,
+					gyldigFra = LocalDateTime.now()
+				)
+			)
+		}
+		log.info("Oppdatert status for ${deltakereSomSkalOppdateres.size} deltakere på gjennomføring som gikk fra kurs til løpende inntak")
+	}
+
+	private fun konverterDeltakerstatuseFraLopendeInntakTilKurs(deltakere: List<Deltaker>, gjennomforingId: UUID) {
+		val deltakereSomSkalOppdateres =
+			deltakere.filter { it.status.type == DeltakerStatus.Type.HAR_SLUTTET }
+
+		if (deltakereSomSkalOppdateres.isNotEmpty()) {
+			val gjennomforing = gjennomforingService.getGjennomforing(gjennomforingId)
+
+			deltakereSomSkalOppdateres.forEach {
+				insertStatus(
+					DeltakerStatusInsert(
+						id = UUID.randomUUID(),
+						deltakerId = it.id,
+						type = getDeltakerStatusType(
+							deltakerSluttdato = it.sluttDato,
+							gjennomforingSluttdato = gjennomforing.sluttDato
+						),
+						aarsak = it.status.aarsak,
+						gyldigFra = LocalDateTime.now()
+					)
+				)
+			}
+		}
+		log.info("Oppdatert status for ${deltakereSomSkalOppdateres.size} deltakere på gjennomføring som gikk fra løpende inntak til kurs")
+	}
+
+	private fun getDeltakerStatusType(deltakerSluttdato: LocalDate?, gjennomforingSluttdato: LocalDate?): DeltakerStatus.Type {
+		return if (gjennomforingSluttdato == null) {
+			DeltakerStatus.Type.AVBRUTT
+		} else if (deltakerSluttdato == null) {
+			DeltakerStatus.Type.FULLFORT
+		} else if (deltakerSluttdato.isBefore(gjennomforingSluttdato)) {
+			DeltakerStatus.Type.AVBRUTT
+		} else {
+			DeltakerStatus.Type.FULLFORT
+		}
 	}
 
 	private fun oppdaterStatus(status: DeltakerStatusInsert): Boolean {

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/services/GjennomforingServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/tiltak/services/GjennomforingServiceImpl.kt
@@ -79,6 +79,10 @@ class GjennomforingServiceImpl(
 
 		if (update.status == UpdateStatus.UPDATED) {
 			gjennomforingRepository.update(update.updatedObject!!)
+
+			if (storedGjennomforing.erKurs != updatedGjennomforing.erKurs) {
+				deltakerService.konverterStatuserForDeltakerePaaGjennomforing(storedGjennomforing.id, updatedGjennomforing.erKurs)
+			}
 		}
 	}
 


### PR DESCRIPTION
https://trello.com/c/aXSOQsTp/1313-konvertere-avsluttende-statuser-p%C3%A5-deltakere-n%C3%A5r-gjennomf%C3%B8ringen-f%C3%A5r-endret-inntaksform

Det er kun avsluttende statuser (fullført, avbrutt og har_sluttet) som er ulikt for kurs/løpende inntak. Når gjennomføringen endrer inntaksform skal alle deltakere med en av disse statusene oppdateres i databasen og publiseres på kafka. 