### PR TITLE
veilarboppfølging trenger tilgang til external-api

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -53,6 +53,9 @@ spec:
           namespace: tpts
         - application: tilleggsstonader-integrasjoner
           namespace: tilleggsstonader
+        - application: veilarboppfolging
+          namespace: pto
+          cluster: dev-fss
     outbound:
       rules:
         - application: amt-person-service

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -53,6 +53,9 @@ spec:
           namespace: tpts
         - application: tilleggsstonader-integrasjoner
           namespace: tilleggsstonader
+        - application: veilarboppfolging
+          namespace: pto
+          cluster: prod-fss
     outbound:
       rules:
         - application: amt-person-service


### PR DESCRIPTION
https://trello.com/c/05BYomuT/1622-veilarboppf%C3%B8lging-lage-sjekk-som-hindrer-at-oppf%C3%B8lgingsperiode-avsluttes-hvis-bruker-har-aktive-tiltaksdeltakelser