### PR TITLE
eget api for å sjekke om bruker har en aktiv deltakelse

### DIFF
--- a/external-api/src/main/kotlin/no/nav/amt/tiltak/external/api/dto/DeltakerDto.kt
+++ b/external-api/src/main/kotlin/no/nav/amt/tiltak/external/api/dto/DeltakerDto.kt
@@ -2,7 +2,7 @@ package no.nav.amt.tiltak.external.api.dto
 
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 class DeltakerDto (
 	val id: UUID,
@@ -13,4 +13,17 @@ class DeltakerDto (
 	val dagerPerUke: Float?,
 	val prosentStilling: Float?,
 	val registrertDato: LocalDateTime,
-)
+) {
+	private val aktiveStatuser = listOf(
+		DeltakerStatusDto.UTKAST_TIL_PAMELDING,
+		DeltakerStatusDto.VENTER_PA_OPPSTART,
+		DeltakerStatusDto.DELTAR,
+		DeltakerStatusDto.SOKT_INN,
+		DeltakerStatusDto.VURDERES,
+		DeltakerStatusDto.VENTELISTE
+	)
+
+	fun erAktiv(): Boolean {
+		return status in aktiveStatuser
+	}
+}

--- a/external-api/src/main/kotlin/no/nav/amt/tiltak/external/api/dto/HarAktiveDeltakelserResponse.kt
+++ b/external-api/src/main/kotlin/no/nav/amt/tiltak/external/api/dto/HarAktiveDeltakelserResponse.kt
@@ -1,0 +1,5 @@
+package no.nav.amt.tiltak.external.api.dto
+
+data class HarAktiveDeltakelserResponse(
+	val harAktiveDeltakelser: Boolean
+)


### PR DESCRIPTION
https://trello.com/c/05BYomuT/1622-veilarboppf%C3%B8lging-lage-sjekk-som-hindrer-at-oppf%C3%B8lgingsperiode-avsluttes-hvis-bruker-har-aktive-tiltaksdeltakelser

Eget api for at domenelogikk om hva som er en aktiv deltakelse ikke skal måtte vedlikeholdes av konsumenter (f.eks. veilarboppfølging). 