### PR TITLE
Work around for å unngå duplicate key exception i tilfelle kafka record med gammel årsak

### DIFF
--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/DeltakerServiceImpl.kt
@@ -288,7 +288,10 @@ open class DeltakerServiceImpl(
 
 	private fun oppdaterStatus(status: DeltakerStatusInsert): Boolean {
 		val forrigeStatus = deltakerStatusRepository.getStatusForDeltaker(status.deltakerId)
-		if (forrigeStatus?.type == status.type && forrigeStatus.aarsak == status.aarsak) return false
+		if (forrigeStatus?.type == status.type && (forrigeStatus.aarsak == status.aarsak
+			|| forrigeStatus.aarsak == DeltakerStatus.Aarsak.SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT && status.aarsak == DeltakerStatus.Aarsak.AVLYST_KONTRAKT)) {
+			return false
+		}
 
 		val nyStatus = DeltakerStatusInsertDbo(
 			id = status.id,


### PR DESCRIPTION
Etter at ryddescript ble kjørt i amt-tiltak og alle deltakere rekjørt, så ble det problemer med innlesning av records hvor årsaken fortsatt var AVLYST_KONTRAKT, fordi consumeren forsøkte å inserte gammel årsak med samme id i databasen.

Tror ikke dette skal bli problem i prod men gjør klar pr i tilfelle relast skulle føre til at mange records står og feiler

https://trello.com/c/zZOu5LmS/1905-erstatte-status%C3%A5rsak-avlystkontrakt-med-samarbeidetmedarrangoreneravbrutt