### PR TITLE
endrer format og api for vurdering

### DIFF
--- a/bff-nav_ansatt/src/main/kotlin/no/nav/amt/tiltak/bff/nav_ansatt/NavAnsattControllerService.kt
+++ b/bff-nav_ansatt/src/main/kotlin/no/nav/amt/tiltak/bff/nav_ansatt/NavAnsattControllerService.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.tiltak.bff.nav_ansatt
 
+import java.util.UUID
 import no.nav.amt.tiltak.bff.nav_ansatt.dto.DeltakerDto
 import no.nav.amt.tiltak.bff.nav_ansatt.dto.EndringsmeldingDto
 import no.nav.amt.tiltak.bff.nav_ansatt.dto.HentGjennomforingerDto
@@ -12,7 +13,7 @@ import no.nav.amt.tiltak.core.domain.tiltak.Adressebeskyttelse
 import no.nav.amt.tiltak.core.domain.tiltak.Deltaker
 import no.nav.amt.tiltak.core.domain.tiltak.Endringsmelding
 import no.nav.amt.tiltak.core.domain.tiltak.Gjennomforing
-import no.nav.amt.tiltak.core.domain.tiltak.Vurdering
+import no.nav.amt.tiltak.core.domain.tiltak.VurderingDbo
 import no.nav.amt.tiltak.core.port.DeltakerService
 import no.nav.amt.tiltak.core.port.EndringsmeldingService
 import no.nav.amt.tiltak.core.port.GjennomforingService
@@ -20,7 +21,6 @@ import no.nav.amt.tiltak.core.port.UnleashService
 import no.nav.amt.tiltak.core.port.VurderingService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 class NavAnsattControllerService(
@@ -120,7 +120,7 @@ class NavAnsattControllerService(
 
 
 	private fun tilVurderingDto(
-		vurdering: Vurdering,
+		vurdering: VurderingDbo,
 		deltakerMap: Map<UUID, Deltaker>,
 		tilganger: List<AdGruppe>,
 	): VurderingDto? {
@@ -185,7 +185,7 @@ class NavAnsattControllerService(
 		}
 	}
 
-	private fun Vurdering.toDto(deltakerDto: DeltakerDto) = VurderingDto(
+	private fun VurderingDbo.toDto(deltakerDto: DeltakerDto) = VurderingDto(
 		id = id,
 		deltaker = deltakerDto,
 		vurderingstype = vurderingstype,

--- a/bff-nav_ansatt/src/test/kotlin/no/nav/amt/tiltak/bff/nav_ansatt/NavAnsattControllerServiceTest.kt
+++ b/bff-nav_ansatt/src/test/kotlin/no/nav/amt/tiltak/bff/nav_ansatt/NavAnsattControllerServiceTest.kt
@@ -3,12 +3,16 @@ package no.nav.amt.tiltak.bff.nav_ansatt
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.util.UUID
 import no.nav.amt.tiltak.bff.nav_ansatt.NavAnsattControllerService.Companion.harTilgangTilDeltaker
 import no.nav.amt.tiltak.bff.nav_ansatt.dto.DeltakerDto
 import no.nav.amt.tiltak.common.auth.AdGruppe
 import no.nav.amt.tiltak.core.domain.tiltak.Adressebeskyttelse
 import no.nav.amt.tiltak.core.domain.tiltak.Endringsmelding
-import no.nav.amt.tiltak.core.domain.tiltak.Vurdering
+import no.nav.amt.tiltak.core.domain.tiltak.VurderingDbo
 import no.nav.amt.tiltak.core.domain.tiltak.Vurderingstype
 import no.nav.amt.tiltak.core.port.DeltakerService
 import no.nav.amt.tiltak.core.port.EndringsmeldingService
@@ -29,10 +33,6 @@ import no.nav.amt.tiltak.test.database.data.TestData.createDeltakerInput
 import no.nav.amt.tiltak.test.database.data.TestData.createStatusInput
 import no.nav.amt.tiltak.test.database.data.inputs.BrukerInput
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZonedDateTime
-import java.util.UUID
 
 class NavAnsattControllerServiceTest {
 	private val endringsmeldingService = mockk<EndringsmeldingService>()
@@ -178,7 +178,7 @@ class NavAnsattControllerServiceTest {
 			innhold = Endringsmelding.Innhold.LeggTilOppstartsdatoInnhold(LocalDate.now()),
 			type = Endringsmelding.Type.LEGG_TIL_OPPSTARTSDATO
 		)
-		val vurdering = Vurdering(
+		val vurdering = VurderingDbo(
 			id = UUID.randomUUID(),
 			deltakerId = DELTAKER_1.id,
 			vurderingstype = Vurderingstype.OPPFYLLER_KRAVENE,
@@ -226,7 +226,7 @@ class NavAnsattControllerServiceTest {
 			innhold = Endringsmelding.Innhold.LeggTilOppstartsdatoInnhold(LocalDate.now()),
 			type = Endringsmelding.Type.LEGG_TIL_OPPSTARTSDATO
 		)
-		val vurdering = Vurdering(
+		val vurdering = VurderingDbo(
 			id = UUID.randomUUID(),
 			deltakerId = deltakerInput.id,
 			vurderingstype = Vurderingstype.OPPFYLLER_KRAVENE,
@@ -274,7 +274,7 @@ class NavAnsattControllerServiceTest {
 			innhold = Endringsmelding.Innhold.LeggTilOppstartsdatoInnhold(LocalDate.now()),
 			type = Endringsmelding.Type.LEGG_TIL_OPPSTARTSDATO
 		)
-		val vurdering = Vurdering(
+		val vurdering = VurderingDbo(
 			id = UUID.randomUUID(),
 			deltakerId = deltakerInput.id,
 			vurderingstype = Vurderingstype.OPPFYLLER_KRAVENE,
@@ -418,7 +418,7 @@ class NavAnsattControllerServiceTest {
 			innhold = Endringsmelding.Innhold.LeggTilOppstartsdatoInnhold(LocalDate.now()),
 			type = Endringsmelding.Type.LEGG_TIL_OPPSTARTSDATO
 		)
-		val vurdering = Vurdering(
+		val vurdering = VurderingDbo(
 			id = UUID.randomUUID(),
 			deltakerId = deltaker.id,
 			vurderingstype = Vurderingstype.OPPFYLLER_KRAVENE,

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/DeltakerController.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/DeltakerController.kt
@@ -1,5 +1,7 @@
 package no.nav.amt.tiltak.bff.tiltaksarrangor
 
+import java.time.LocalDate
+import java.util.UUID
 import no.nav.amt.tiltak.bff.tiltaksarrangor.request.AvsluttDeltakelseRequest
 import no.nav.amt.tiltak.bff.tiltaksarrangor.request.DeltakerIkkeAktuellRequest
 import no.nav.amt.tiltak.bff.tiltaksarrangor.request.EndreOppstartsdatoRequest
@@ -23,8 +25,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDate
-import java.util.UUID
 
 @RestController
 @RequestMapping("/api/tiltaksarrangor/deltaker")
@@ -167,10 +167,14 @@ class DeltakerController(
 		arrangorAnsattTilgangService.verifiserTilgangTilDeltaker(ansatt.id, deltakerId)
 
 		return deltakerService.lagreVurdering(
-			deltakerId = deltakerId,
-			arrangorAnsattId = ansatt.id,
-			vurderingstype = request.vurderingstype,
-			begrunnelse = request.begrunnelse
+			Vurdering(
+				id = request.id,
+				deltakerId = deltakerId,
+				opprettet = request.opprettet,
+				opprettetAvArrangorAnsattId = ansatt.id,
+				vurderingstype = request.vurderingstype,
+				begrunnelse = request.begrunnelse
+			)
 		)
 	}
 

--- a/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/request/RegistrerVurderingRequest.kt
+++ b/bff-tiltaksarrangor/src/main/kotlin/no/nav/amt/tiltak/bff/tiltaksarrangor/request/RegistrerVurderingRequest.kt
@@ -1,8 +1,12 @@
 package no.nav.amt.tiltak.bff.tiltaksarrangor.request
 
+import java.time.LocalDateTime
+import java.util.UUID
 import no.nav.amt.tiltak.core.domain.tiltak.Vurderingstype
 
 data class RegistrerVurderingRequest(
+	val id: UUID,
+	val opprettet: LocalDateTime,
     val vurderingstype: Vurderingstype,
     val begrunnelse: String?
 )

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Vurdering.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Vurdering.kt
@@ -1,8 +1,10 @@
 package no.nav.amt.tiltak.core.domain.tiltak
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.time.LocalDateTime
 import java.util.UUID
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.SIMPLE_NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 data class Vurdering(
 	val id: UUID,
 	val deltakerId: UUID,

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Vurdering.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/Vurdering.kt
@@ -9,6 +9,5 @@ data class Vurdering(
 	val vurderingstype: Vurderingstype,
 	val begrunnelse: String?,
 	val opprettetAvArrangorAnsattId: UUID,
-	val gyldigFra: LocalDateTime,
-	val gyldigTil: LocalDateTime?
+	val opprettet: LocalDateTime,
 )

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/VurderingDbo.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/domain/tiltak/VurderingDbo.kt
@@ -1,0 +1,24 @@
+package no.nav.amt.tiltak.core.domain.tiltak
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class VurderingDbo(
+	val id: UUID,
+	val deltakerId: UUID,
+	val vurderingstype: Vurderingstype,
+	val begrunnelse: String?,
+	val opprettetAvArrangorAnsattId: UUID,
+	val gyldigFra: LocalDateTime,
+	val gyldigTil: LocalDateTime?
+) {
+	fun toVurdering(): Vurdering =
+		Vurdering(
+			id = id,
+			deltakerId = deltakerId,
+			vurderingstype = vurderingstype,
+			begrunnelse = begrunnelse,
+			opprettetAvArrangorAnsattId = opprettetAvArrangorAnsattId,
+			opprettet = gyldigFra
+		)
+}

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/DeltakerService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/DeltakerService.kt
@@ -44,7 +44,7 @@ interface DeltakerService {
 
 	fun avsluttDeltakerePaaAvbruttGjennomforing(gjennomforingId: UUID)
 
-	fun lagreVurdering(deltakerId: UUID, arrangorAnsattId: UUID, vurderingstype: Vurderingstype, begrunnelse: String?): List<Vurdering>
+	fun lagreVurdering(vurdering: Vurdering): List<Vurdering>
 
 	fun konverterStatuserForDeltakerePaaGjennomforing(gjennomforingId: UUID, oppdatertGjennomforingErKurs: Boolean)
 }

--- a/core/src/main/kotlin/no/nav/amt/tiltak/core/port/VurderingService.kt
+++ b/core/src/main/kotlin/no/nav/amt/tiltak/core/port/VurderingService.kt
@@ -1,8 +1,8 @@
 package no.nav.amt.tiltak.core.port
 
-import no.nav.amt.tiltak.core.domain.tiltak.Vurdering
 import java.util.UUID
+import no.nav.amt.tiltak.core.domain.tiltak.VurderingDbo
 
 interface VurderingService {
-	fun hentAktiveVurderingerForGjennomforing(gjennomforingId: UUID): List<Vurdering>
+	fun hentAktiveVurderingerForGjennomforing(gjennomforingId: UUID): List<VurderingDbo>
 }

--- a/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/publish/DeltakerPublishQuery.kt
+++ b/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/publish/DeltakerPublishQuery.kt
@@ -174,8 +174,7 @@ class DeltakerPublishQuery(
 			vurderingstype = Vurderingstype.valueOf(rs.getString("vurderingstype")),
 			begrunnelse = rs.getString("begrunnelse"),
 			opprettetAvArrangorAnsattId = rs.getUUID("opprettet_av_arrangor_ansatt_id"),
-			gyldigFra = rs.getLocalDateTime("gyldig_fra"),
-			gyldigTil = rs.getNullableLocalDateTime("gyldig_til")
+			opprettet = rs.getLocalDateTime("gyldig_fra")
 		)
 	}
 

--- a/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/nav_ansatt/EndringsmeldingControllerIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/nav_ansatt/EndringsmeldingControllerIntegrationTest.kt
@@ -1,8 +1,10 @@
 package no.nav.amt.tiltak.test.integration.nav_ansatt
 
 import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+import java.util.UUID
 import no.nav.amt.tiltak.core.domain.tiltak.Endringsmelding
-import no.nav.amt.tiltak.core.domain.tiltak.Vurdering
+import no.nav.amt.tiltak.core.domain.tiltak.VurderingDbo
 import no.nav.amt.tiltak.core.domain.tiltak.Vurderingstype
 import no.nav.amt.tiltak.deltaker.repositories.VurderingRepository
 import no.nav.amt.tiltak.endringsmelding.EndringsmeldingRepository
@@ -23,8 +25,6 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.LocalDateTime
-import java.util.UUID
 
 class EndringsmeldingControllerIntegrationTest : IntegrationTestBase() {
 
@@ -395,8 +395,8 @@ class EndringsmeldingControllerIntegrationTest : IntegrationTestBase() {
 		return endringsmelding
 	}
 
-	private fun insertVurdering(deltakerId: UUID): Vurdering {
-		val vurdering = Vurdering(
+	private fun insertVurdering(deltakerId: UUID): VurderingDbo {
+		val vurdering = VurderingDbo(
 			id = UUID.fromString("866a387f-87d1-4623-8010-32fcdea5464e"),
 			deltakerId = deltakerId,
 			vurderingstype = Vurderingstype.OPPFYLLER_KRAVENE,

--- a/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/DeltakerControllerIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/DeltakerControllerIntegrationTest.kt
@@ -17,6 +17,7 @@ import no.nav.amt.tiltak.core.port.DeltakerService
 import no.nav.amt.tiltak.core.port.EndringsmeldingService
 import no.nav.amt.tiltak.deltaker.repositories.VurderingRepository
 import no.nav.amt.tiltak.test.database.DbTestDataUtils
+import no.nav.amt.tiltak.test.database.DbUtils.shouldBeCloseTo
 import no.nav.amt.tiltak.test.database.data.TestData.ARRANGOR_ANSATT_1
 import no.nav.amt.tiltak.test.database.data.TestData.ARRANGOR_ANSATT_2
 import no.nav.amt.tiltak.test.database.data.TestData.DELTAKER_1
@@ -407,7 +408,7 @@ class DeltakerControllerIntegrationTest : IntegrationTestBase() {
 			method = "POST",
 			url = "/api/tiltaksarrangor/deltaker/${deltakerIkkeTilgang.id}/vurdering",
 			headers = createAnsatt1AuthHeader(),
-			body = """{"vurderingstype": "OPPFYLLER_IKKE_KRAVENE", "begrunnelse": "Mangler førerkort"}""".toJsonRequestBody()
+			body = """{"id": "${UUID.randomUUID()}", "opprettet": ${objectMapper.writeValueAsString(LocalDateTime.now())}, "vurderingstype": "OPPFYLLER_IKKE_KRAVENE", "begrunnelse": "Mangler førerkort"}""".toJsonRequestBody()
 		)
 
 		response.code shouldBe 403
@@ -442,7 +443,7 @@ class DeltakerControllerIntegrationTest : IntegrationTestBase() {
 		vurderingerFraResponse?.id shouldBe id
 		vurderingerFraResponse?.vurderingstype shouldBe Vurderingstype.OPPFYLLER_IKKE_KRAVENE
 		vurderingerFraResponse?.begrunnelse shouldBe "Mangler førerkort"
-		vurderingerFraResponse?.opprettet shouldBe opprettet
+		vurderingerFraResponse?.opprettet!! shouldBeCloseTo opprettet
 	}
 
 	@Test

--- a/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/DeltakerControllerIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/no/nav/amt/tiltak/test/integration/tiltaksarrangor/DeltakerControllerIntegrationTest.kt
@@ -4,7 +4,11 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beInstanceOf
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
 import no.nav.amt.tiltak.common.json.JsonUtils.fromJsonString
+import no.nav.amt.tiltak.common.json.JsonUtils.objectMapper
 import no.nav.amt.tiltak.core.domain.tiltak.Endringsmelding
 import no.nav.amt.tiltak.core.domain.tiltak.EndringsmeldingStatusAarsak
 import no.nav.amt.tiltak.core.domain.tiltak.Vurdering
@@ -24,8 +28,6 @@ import okhttp3.Request
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.LocalDate
-import java.util.UUID
 
 class DeltakerControllerIntegrationTest : IntegrationTestBase() {
 
@@ -413,7 +415,9 @@ class DeltakerControllerIntegrationTest : IntegrationTestBase() {
 
 	@Test
 	fun `registrerVurdering() skal returnere 200 og opprette vurdering`() {
+		val id = UUID.randomUUID()
 		val deltakerId = UUID.randomUUID()
+		val opprettet = LocalDateTime.now()
 		testDataRepository.insertDeltaker(DELTAKER_1.copy(id = deltakerId))
 		testDataRepository.insertDeltakerStatus(DELTAKER_1_STATUS_1.copy(id = UUID.randomUUID(), deltakerId = deltakerId, status = "VURDERES"))
 
@@ -421,7 +425,7 @@ class DeltakerControllerIntegrationTest : IntegrationTestBase() {
 			method = "POST",
 			url = "/api/tiltaksarrangor/deltaker/$deltakerId/vurdering",
 			headers = createAnsatt1AuthHeader(),
-			body = """{"vurderingstype": "OPPFYLLER_IKKE_KRAVENE", "begrunnelse": "Mangler førerkort"}""".toJsonRequestBody()
+			body = """{"id": "$id", "opprettet": ${objectMapper.writeValueAsString(opprettet)}, "vurderingstype": "OPPFYLLER_IKKE_KRAVENE", "begrunnelse": "Mangler førerkort"}""".toJsonRequestBody()
 		)
 
 		response.code shouldBe 200
@@ -430,13 +434,15 @@ class DeltakerControllerIntegrationTest : IntegrationTestBase() {
 		vurderinger shouldHaveSize 1
 
 		val vurdering = vurderinger.first()
+		vurdering.id shouldBe id
 		vurdering.vurderingstype shouldBe Vurderingstype.OPPFYLLER_IKKE_KRAVENE
 		vurdering.begrunnelse shouldBe "Mangler førerkort"
 		vurdering.gyldigTil shouldBe null
 		val vurderingerFraResponse = response.body?.string()?.let { fromJsonString<List<Vurdering>>(it) }?.firstOrNull()
+		vurderingerFraResponse?.id shouldBe id
 		vurderingerFraResponse?.vurderingstype shouldBe Vurderingstype.OPPFYLLER_IKKE_KRAVENE
 		vurderingerFraResponse?.begrunnelse shouldBe "Mangler førerkort"
-		vurderingerFraResponse?.gyldigTil shouldBe null
+		vurderingerFraResponse?.opprettet shouldBe opprettet
 	}
 
 	@Test
@@ -445,7 +451,7 @@ class DeltakerControllerIntegrationTest : IntegrationTestBase() {
 			method = "POST",
 			url = "/api/tiltaksarrangor/deltaker/${DELTAKER_1.id}/vurdering",
 			headers = createAnsatt1AuthHeader(),
-			body = """{"vurderingstype": "OPPFYLLER_IKKE_KRAVENE", "begrunnelse": "Mangler førerkort"}""".toJsonRequestBody()
+			body = """{"id": "${UUID.randomUUID()}", "opprettet": ${objectMapper.writeValueAsString(LocalDateTime.now())}, "vurderingstype": "OPPFYLLER_IKKE_KRAVENE", "begrunnelse": "Mangler førerkort"}""".toJsonRequestBody()
 		)
 
 		response.code shouldBe 400

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/repositories/VurderingRepository.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/repositories/VurderingRepository.kt
@@ -1,7 +1,6 @@
 package no.nav.amt.tiltak.deltaker.repositories
 
 import no.nav.amt.tiltak.common.db_utils.DbUtils
-import no.nav.amt.tiltak.core.domain.tiltak.Vurdering
 import no.nav.amt.tiltak.core.domain.tiltak.Vurderingstype
 import no.nav.amt.tiltak.utils.getLocalDateTime
 import no.nav.amt.tiltak.utils.getNullableLocalDateTime
@@ -12,13 +11,14 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 import java.util.UUID
+import no.nav.amt.tiltak.core.domain.tiltak.VurderingDbo
 
 @Component
 open class VurderingRepository(
 	private val template: NamedParameterJdbcTemplate
 ) {
 	private val rowMapper = RowMapper { rs, _ ->
-		Vurdering(
+		VurderingDbo(
 			id = rs.getUUID("id"),
 			deltakerId = rs.getUUID("deltaker_id"),
 			vurderingstype = Vurderingstype.valueOf(rs.getString("vurderingstype")),
@@ -29,7 +29,7 @@ open class VurderingRepository(
 		)
 	}
 
-	fun getVurderingerForDeltaker(deltakerId: UUID): List<Vurdering> {
+	fun getVurderingerForDeltaker(deltakerId: UUID): List<VurderingDbo> {
 		val sql = """
 			SELECT *
 			FROM vurdering
@@ -43,7 +43,7 @@ open class VurderingRepository(
 		return template.query(sql, parameters, rowMapper)
 	}
 
-	fun getAktiveByGjennomforing(gjennomforingId: UUID): List<Vurdering> {
+	fun getAktiveByGjennomforing(gjennomforingId: UUID): List<VurderingDbo> {
 		val sql = """
 			SELECT *
 			FROM vurdering
@@ -56,7 +56,7 @@ open class VurderingRepository(
 		return template.query(sql, param, rowMapper)
 	}
 
-	fun insert(vurdering: Vurdering) {
+	fun insert(vurdering: VurderingDbo) {
 		val sql = """
 			INSERT INTO vurdering (id, deltaker_id, opprettet_av_arrangor_ansatt_id, vurderingstype, begrunnelse, gyldig_fra, gyldig_til)
 			VALUES (

--- a/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/VurderingServiceImpl.kt
+++ b/tiltak/src/main/kotlin/no/nav/amt/tiltak/deltaker/service/VurderingServiceImpl.kt
@@ -1,16 +1,16 @@
 package no.nav.amt.tiltak.deltaker.service
 
-import no.nav.amt.tiltak.core.domain.tiltak.Vurdering
+import java.util.UUID
+import no.nav.amt.tiltak.core.domain.tiltak.VurderingDbo
 import no.nav.amt.tiltak.core.port.VurderingService
 import no.nav.amt.tiltak.deltaker.repositories.VurderingRepository
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 class VurderingServiceImpl(
 	private val vurderingRepository: VurderingRepository
 ) : VurderingService {
-	override fun hentAktiveVurderingerForGjennomforing(gjennomforingId: UUID): List<Vurdering> {
+	override fun hentAktiveVurderingerForGjennomforing(gjennomforingId: UUID): List<VurderingDbo> {
 		return vurderingRepository.getAktiveByGjennomforing(gjennomforingId)
 	}
 }

--- a/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/service/VurderingServiceImplTest.kt
+++ b/tiltak/src/test/kotlin/no/nav/amt/tiltak/deltaker/service/VurderingServiceImplTest.kt
@@ -1,7 +1,9 @@
 package no.nav.amt.tiltak.deltaker.service
 
 import io.kotest.matchers.shouldBe
-import no.nav.amt.tiltak.core.domain.tiltak.Vurdering
+import java.time.LocalDateTime
+import java.util.UUID
+import no.nav.amt.tiltak.core.domain.tiltak.VurderingDbo
 import no.nav.amt.tiltak.core.domain.tiltak.Vurderingstype
 import no.nav.amt.tiltak.deltaker.repositories.VurderingRepository
 import no.nav.amt.tiltak.test.database.DbTestDataUtils
@@ -10,8 +12,6 @@ import no.nav.amt.tiltak.test.database.data.TestData
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import java.time.LocalDateTime
-import java.util.UUID
 
 class VurderingServiceImplTest {
 	val dataSource = SingletonPostgresContainer.getDataSource()
@@ -26,7 +26,7 @@ class VurderingServiceImplTest {
 
 	@Test
 	fun `hentAktiveVurderingerForGjennomforing - henter aktive vurderinger pa gjennomforing`() {
-		vurderingRepository.insert(Vurdering(
+		vurderingRepository.insert(VurderingDbo(
 			UUID.randomUUID(),
 			TestData.DELTAKER_1.id,
 			Vurderingstype.OPPFYLLER_IKKE_KRAVENE,
@@ -35,7 +35,7 @@ class VurderingServiceImplTest {
 			gyldigFra = LocalDateTime.now(),
 			gyldigTil = null
 		))
-		vurderingRepository.insert(Vurdering(
+		vurderingRepository.insert(VurderingDbo(
 			UUID.randomUUID(),
 			TestData.DELTAKER_1.id,
 			Vurderingstype.OPPFYLLER_KRAVENE,
@@ -44,7 +44,7 @@ class VurderingServiceImplTest {
 			gyldigFra = LocalDateTime.now(),
 			gyldigTil = LocalDateTime.now()
 		))
-		vurderingRepository.insert(Vurdering(
+		vurderingRepository.insert(VurderingDbo(
 			UUID.randomUUID(),
 			TestData.DELTAKER_2.id,
 			Vurderingstype.OPPFYLLER_KRAVENE,


### PR DESCRIPTION
https://trello.com/c/vWhuVSEK/2059-amt-tiltaksarrangor-bff-m%C3%A5-dele-vurdering-fra-arrang%C3%B8r-p%C3%A5-topic

Dette er en veldig breaking change og må ikke merges uten at tilhørende endring i bff merges samtidig (og på kveldstid). Etterpå må vi relaste alle deltakere på gruppeamo slik at vurderinger både på topic og i bff får riktig format. 

Vi ønsker ikke å endre formatet som brukes i databasen eller ut mot tiltaksansvarlig (derfor brukes dbo-objektet også ut i navansatt-laget). Formatet som brukes mot tiltaksarrangør og i deltaker-v2 skal stemme overens med formatet som er definert i amt-lib. 