### PR TITLE
Flytter generering av importertFraArena element

### DIFF
--- a/data-publisher/pom.xml
+++ b/data-publisher/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>db_utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>no.nav.amt.lib</groupId>
+            <artifactId>models</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.arrow-kt</groupId>
             <artifactId>arrow-core</artifactId>
             <version>2.0.0</version>

--- a/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/model/DeltakerPublishDto.kt
+++ b/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/model/DeltakerPublishDto.kt
@@ -5,6 +5,7 @@ import no.nav.amt.tiltak.core.domain.tiltak.Adressebeskyttelse
 import no.nav.amt.tiltak.core.domain.tiltak.DeltakerStatus
 import no.nav.amt.tiltak.core.domain.tiltak.Kilde
 import no.nav.amt.tiltak.core.domain.tiltak.Vurdering
+import no.nav.amt.lib.models.deltaker.DeltakerHistorikk
 import no.nav.common.json.JsonUtils
 import org.springframework.util.DigestUtils
 import java.time.LocalDate
@@ -26,6 +27,7 @@ data class DeltakerPublishDto(
 	val navVeileder: DeltakerNavVeilederDto?,
 	val deltarPaKurs: Boolean,
 	val vurderingerFraArrangor: List<Vurdering>?,
+	val historikk: List<DeltakerHistorikk>?,
 	val kilde: Kilde?,
 	val forsteVedtakFattet: LocalDate?,
 	val sistEndretAv: UUID?,

--- a/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/publish/DeltakerPublishQuery.kt
+++ b/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/publish/DeltakerPublishQuery.kt
@@ -119,7 +119,7 @@ class DeltakerPublishQuery(
 		dagerPerUke = dagerPerUke,
 		deltakelsesprosent = prosentStilling?.toFloat(),
 		status = no.nav.amt.lib.models.deltaker.DeltakerStatus(
-			id = id,
+			id = status.id ?: throw IllegalStateException("Deltaker status ikke satt"),
 			type = no.nav.amt.lib.models.deltaker.DeltakerStatus.Type.valueOf(status.type.name),
 			aarsak = status.aarsak?.let {no.nav.amt.lib.models.deltaker.DeltakerStatus.Aarsak(
 				type = no.nav.amt.lib.models.deltaker.DeltakerStatus.Aarsak.Type.valueOf(status.aarsak.name),

--- a/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/publish/DeltakerPublishQuery.kt
+++ b/data-publisher/src/main/kotlin/no/nav/amt/tiltak/data_publisher/publish/DeltakerPublishQuery.kt
@@ -1,5 +1,8 @@
 package no.nav.amt.tiltak.data_publisher.publish
 
+import no.nav.amt.lib.models.deltaker.DeltakerHistorikk
+import no.nav.amt.lib.models.deltaker.DeltakerVedImport
+import no.nav.amt.lib.models.deltaker.ImportertFraArena
 import no.nav.amt.tiltak.common.db_utils.DbUtils.sqlParameters
 import no.nav.amt.tiltak.common.db_utils.getLocalDate
 import no.nav.amt.tiltak.common.db_utils.getLocalDateTime
@@ -29,6 +32,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class DeltakerPublishQuery(

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <common.version>3.2024.10.25_13.44-9db48a0dbe67</common.version>
         <logstash.version>8.0</logstash.version>
         <unleash.version>9.2.6</unleash.version>
+        <amtlib.version>1.2025.01.09_06.01-9f86501854f1</amtlib.version>
     </properties>
 
     <repositories>
@@ -145,6 +146,12 @@
                 <artifactId>kafka-producer</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>no.nav.amt.lib</groupId>
+                <artifactId>models</artifactId>
+                <version>${amtlib.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>


### PR DESCRIPTION
For å:
 * lage en mer naturlig flyt
 * Unngå problemstillinger med at amt-deltaker leser og publiserer til samme topic i deltaker-v2 konsumenten når vi skal ta over de neste tiltakstypene

Oppdatering av historikkelementet skjer hver gang det kommer endringer fra arena OG vi ikke enda er master for tiltakstypen

https://trello.com/c/tJEGBXqg/2084-lese-inn-kursdeltakere-i-verdikjeden