### PR TITLE
Bump Dependencies - 20250226161610

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <common.version>3.2024.10.25_13.44-9db48a0dbe67</common.version>
         <logstash.version>8.0</logstash.version>
         <unleash.version>10.0.2</unleash.version>
-        <amtlib.version>1.2025.02.12_11.31-6ed3c891d00f</amtlib.version>
+        <amtlib.version>1.2025.02.25_13.39-0d9463c72c24</amtlib.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250226161610 branch: