### PR TITLE
Bump Dependencies - 20250227092344

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <common.version>3.2024.10.25_13.44-9db48a0dbe67</common.version>
         <logstash.version>8.0</logstash.version>
         <unleash.version>10.0.2</unleash.version>
-        <amtlib.version>1.2025.02.25_13.39-0d9463c72c24</amtlib.version>
+        <amtlib.version>1.2025.02.26_09.34-c938c3d93f24</amtlib.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <testcontainers.version>1.20.5</testcontainers.version>
         <mockito-kotlin.version>5.4.0</mockito-kotlin.version>
         <schedlock.version>6.3.0</schedlock.version>
-        <nimbus.version>11.23</nimbus.version>
+        <nimbus.version>11.23.1</nimbus.version>
         <mockk.version>1.13.16</mockk.version>
         <kotest.version>5.6.1</kotest.version>
         <okhttp.version>4.12.0</okhttp.version>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250227092344 branch:

- [Bump com.nimbusds:oauth2-oidc-sdk from 11.23 to 11.23.1](https://github.com/navikt/amt-tiltak/pull/943)
- [Bump no.nav.amt.lib:models from 1.2025.02.25_13.39-0d9463c72c24 to 1.2025.02.26_09.34-c938c3d93f24](https://github.com/navikt/amt-tiltak/pull/942)
