### PR TITLE
Bump dependencies - 20250304085447

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
             <dependency>
                 <groupId>no.nav.poao-tilgang</groupId>
                 <artifactId>client</artifactId>
-                <version>2025.02.18_14.13-ac4265f31ef3</version>
+                <version>2025.03.03_11.15-706bb97e7558</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <mockk.version>1.13.17</mockk.version>
         <kotest.version>5.6.1</kotest.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <token-support.version>5.0.17</token-support.version>
+        <token-support.version>5.0.19</token-support.version>
         <mock-oauth2-server.version>2.1.10</mock-oauth2-server.version>
         <common.version>3.2024.10.25_13.44-9db48a0dbe67</common.version>
         <logstash.version>8.0</logstash.version>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250304085447 branch:

- [Bump no.nav.poao-tilgang:client from 2025.02.18_14.13-ac4265f31ef3 to 2025.03.03_11.15-706bb97e7558](https://github.com/navikt/amt-tiltak/pull/948)
- [Bump no.nav.security:token-validation-spring from 5.0.17 to 5.0.19](https://github.com/navikt/amt-tiltak/pull/947)
