### PR TITLE
Bump dependencies - 20250704093322

### DIFF
--- a/clients/amt-arrangor-client/pom.xml
+++ b/clients/amt-arrangor-client/pom.xml
@@ -18,7 +18,7 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <dependency>

--- a/clients/amt-person/pom.xml
+++ b/clients/amt-person/pom.xml
@@ -18,7 +18,7 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <dependency>

--- a/clients/mulighetsrommet-api-client/pom.xml
+++ b/clients/mulighetsrommet-api-client/pom.xml
@@ -18,7 +18,7 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <dependency>

--- a/kafka/kafka-config/src/main/kotlin/no/nav/amt/tiltak/kafka/config/KafkaConfiguration.kt
+++ b/kafka/kafka-config/src/main/kotlin/no/nav/amt/tiltak/kafka/config/KafkaConfiguration.kt
@@ -14,7 +14,6 @@ import no.nav.common.kafka.consumer.feilhandtering.util.KafkaConsumerRecordProce
 import no.nav.common.kafka.consumer.util.KafkaConsumerClientBuilder
 import no.nav.common.kafka.consumer.util.deserializer.Deserializers.stringDeserializer
 import no.nav.common.kafka.spring.PostgresJdbcTemplateConsumerRepository
-import okhttp3.internal.toImmutableList
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -138,7 +137,7 @@ open class KafkaConfiguration(
 
 		client = KafkaConsumerClientBuilder.builder()
             .withProperties(kafkaProperties.consumer())
-            .withTopicConfigs(topicConfigs.toImmutableList())
+            .withTopicConfigs(topicConfigs.toList())
             .build()
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <nimbus.version>11.26</nimbus.version>
         <mockk.version>1.14.4</mockk.version>
         <kotest.version>5.6.1</kotest.version>
-        <okhttp.version>4.12.0</okhttp.version>
+        <okhttp.version>5.0.0</okhttp.version>
         <token-support.version>5.0.30</token-support.version>
         <mock-oauth2-server.version>2.2.1</mock-oauth2-server.version>
         <common.version>3.2025.05.30_07.00-bef2e550fb22</common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <common.version>3.2025.05.30_07.00-bef2e550fb22</common.version>
         <logstash.version>8.1</logstash.version>
         <unleash.version>11.0.1</unleash.version>
-        <amtlib.version>1.2025.06.17_13.45-d25e1dc4de19</amtlib.version>
+        <amtlib.version>1.2025.07.03_09.15-e63d3f075ead</amtlib.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <mock-oauth2-server.version>2.2.1</mock-oauth2-server.version>
         <common.version>3.2025.05.30_07.00-bef2e550fb22</common.version>
         <logstash.version>8.1</logstash.version>
-        <unleash.version>11.0.0</unleash.version>
+        <unleash.version>11.0.1</unleash.version>
         <amtlib.version>1.2025.06.17_13.45-d25e1dc4de19</amtlib.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,12 @@
                 <groupId>no.nav.common</groupId>
                 <artifactId>job</artifactId>
                 <version>${common.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>okhttp</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>no.nav.common</groupId>
@@ -362,12 +368,23 @@
                 <groupId>no.nav.poao-tilgang</groupId>
                 <artifactId>client</artifactId>
                 <version>2025.07.01_08.44-8cfc2e4afeda</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>okhttp</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
                 <groupId>no.nav.security</groupId>
                 <artifactId>token-validation-spring</artifactId>
                 <version>${token-support.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-jvm</artifactId>
+                <version>${okhttp.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
             <dependency>
                 <groupId>no.nav.poao-tilgang</groupId>
                 <artifactId>client</artifactId>
-                <version>2025.06.06_07.18-71cefb1c2699</version>
+                <version>2025.07.01_08.44-8cfc2e4afeda</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
 
-        <testcontainers.version>1.21.2</testcontainers.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
         <mockito-kotlin.version>5.4.0</mockito-kotlin.version>
         <schedlock.version>6.9.0</schedlock.version>
         <nimbus.version>11.26</nimbus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>
-        <kotlin.version>2.1.21</kotlin.version>
+        <kotlin.version>2.2.0</kotlin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <mockito-kotlin.version>5.4.0</mockito-kotlin.version>
         <schedlock.version>6.9.0</schedlock.version>
         <nimbus.version>11.26</nimbus.version>
-        <mockk.version>1.14.2</mockk.version>
+        <mockk.version>1.14.4</mockk.version>
         <kotest.version>5.6.1</kotest.version>
         <okhttp.version>4.12.0</okhttp.version>
         <token-support.version>5.0.30</token-support.version>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250704093322 branch:

## Successfully Rebased PRs
- [Bump no.nav.amt.lib:models from 1.2025.06.17_13.45-d25e1dc4de19 to 1.2025.07.03_09.15-e63d3f075ead](https://github.com/navikt/amt-tiltak/pull/1054)
- [Bump okhttp.version from 4.12.0 to 5.0.0](https://github.com/navikt/amt-tiltak/pull/1053)
- [Bump no.nav.poao-tilgang:client from 2025.06.06_07.18-71cefb1c2699 to 2025.07.01_08.44-8cfc2e4afeda](https://github.com/navikt/amt-tiltak/pull/1050)
- [Bump io.getunleash:unleash-client-java from 11.0.0 to 11.0.1](https://github.com/navikt/amt-tiltak/pull/1049)
- [Bump testcontainers.version from 1.21.2 to 1.21.3](https://github.com/navikt/amt-tiltak/pull/1048)
- [Bump mockk.version from 1.14.2 to 1.14.4](https://github.com/navikt/amt-tiltak/pull/1044)
- [Bump kotlin.version from 2.1.21 to 2.2.0](https://github.com/navikt/amt-tiltak/pull/1042)


