### PR TITLE
Bump dependencies - 20250721114219

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <maven.compiler.target>21</maven.compiler.target>
 
         <testcontainers.version>1.21.3</testcontainers.version>
-        <mockito-kotlin.version>5.4.0</mockito-kotlin.version>
+        <mockito-kotlin.version>6.0.0</mockito-kotlin.version>
         <schedlock.version>6.9.2</schedlock.version>
         <nimbus.version>11.26</nimbus.version>
         <mockk.version>1.14.5</mockk.version>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250721114219 branch:

## Successfully Rebased PRs
- [Bump org.mockito.kotlin:mockito-kotlin from 5.4.0 to 6.0.0](https://github.com/navikt/amt-tiltak/pull/1064)
- [Bump mockk.version from 1.14.4 to 1.14.5](https://github.com/navikt/amt-tiltak/pull/1063)


