### PR TITLE
Bump dependencies - 20250728094107

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <mockk.version>1.14.5</mockk.version>
         <kotest.version>5.6.1</kotest.version>
         <okhttp.version>5.1.0</okhttp.version>
-        <token-support.version>5.0.30</token-support.version>
+        <token-support.version>5.0.33</token-support.version>
         <mock-oauth2-server.version>2.2.1</mock-oauth2-server.version>
         <common.version>3.2025.06.23_14.50-3af3985d8555</common.version>
         <logstash.version>8.1</logstash.version>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250728094107 branch:

## Successfully Rebased PRs
- [Bump no.nav.security:token-validation-spring from 5.0.30 to 5.0.33](https://github.com/navikt/amt-tiltak/pull/1070)
- [Bump com.nimbusds:oauth2-oidc-sdk from 11.26 to 11.26.1](https://github.com/navikt/amt-tiltak/pull/1069)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.5.3 to 3.5.4](https://github.com/navikt/amt-tiltak/pull/1068)


