### PR TITLE
Bump dependencies - 20250909080122

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <kotest.version>5.6.1</kotest.version>
         <okhttp.version>5.1.0</okhttp.version>
         <token-support.version>5.0.34</token-support.version>
-        <mock-oauth2-server.version>2.2.1</mock-oauth2-server.version>
+        <mock-oauth2-server.version>2.3.0</mock-oauth2-server.version>
         <common.version>3.2025.08.18_11.44-04fe318bd185</common.version>
         <logstash.version>8.1</logstash.version>
         <unleash.version>11.1.0</unleash.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <testcontainers.version>1.21.3</testcontainers.version>
         <mockito-kotlin.version>6.0.0</mockito-kotlin.version>
         <schedlock.version>6.10.0</schedlock.version>
-        <nimbus.version>11.27.1</nimbus.version>
+        <nimbus.version>11.28</nimbus.version>
         <mockk.version>1.14.5</mockk.version>
         <kotest.version>5.6.1</kotest.version>
         <okhttp.version>5.1.0</okhttp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>4.0.0</version>
+                <version>4.1.0</version>
             </dependency>
             <dependency>
                 <groupId>no.nav.amt-tiltak</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <common.version>3.2025.08.18_11.44-04fe318bd185</common.version>
         <logstash.version>8.1</logstash.version>
         <unleash.version>11.1.0</unleash.version>
-        <amtlib.version>1.2025.08.20_15.50-3010e3ffdb61</amtlib.version>
+        <amtlib.version>1.2025.09.05_08.24-2bd638d77442</amtlib.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250909080122 branch:

## Successfully Rebased PRs
- [Bump no.nav.amt.lib:models from 1.2025.08.20_15.50-3010e3ffdb61 to 1.2025.09.05_08.24-2bd638d77442](https://github.com/navikt/amt-tiltak/pull/1098)
- [Bump no.nav.security:mock-oauth2-server from 2.2.1 to 2.3.0](https://github.com/navikt/amt-tiltak/pull/1096)
- [Bump com.nimbusds:oauth2-oidc-sdk from 11.27.1 to 11.28](https://github.com/navikt/amt-tiltak/pull/1095)
- [Bump org.apache.kafka:kafka-clients from 4.0.0 to 4.1.0](https://github.com/navikt/amt-tiltak/pull/1094)
- [Bump actions/setup-java from 4 to 5](https://github.com/navikt/amt-tiltak/pull/1090)


