### PR TITLE
Bump dependencies - 20250919083621

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>3.5.4</version>
             </plugin>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
             <dependency>
                 <groupId>no.nav.poao-tilgang</groupId>
                 <artifactId>client</artifactId>
-                <version>2025.07.04_08.56-814fa50f6740</version>
+                <version>2025.09.15_11.12-54be8ac278c0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <common.version>3.2025.08.18_11.44-04fe318bd185</common.version>
         <logstash.version>8.1</logstash.version>
         <unleash.version>11.1.0</unleash.version>
-        <amtlib.version>1.2025.09.12_14.27-34cc8282593a</amtlib.version>
+        <amtlib.version>1.2025.09.15_08.19-1c6bc06d65fe</amtlib.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <kotest.version>5.6.1</kotest.version>
         <okhttp.version>5.1.0</okhttp.version>
         <token-support.version>5.0.34</token-support.version>
-        <mock-oauth2-server.version>2.3.0</mock-oauth2-server.version>
+        <mock-oauth2-server.version>3.0.0</mock-oauth2-server.version>
         <common.version>3.2025.08.18_11.44-04fe318bd185</common.version>
         <logstash.version>8.1</logstash.version>
         <unleash.version>11.1.0</unleash.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <artifactId>spring-boot-starter-parent</artifactId>
         <groupId>org.springframework.boot</groupId>
-        <version>3.5.5</version>
+        <version>3.5.6</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250919083621 branch:

## Successfully Rebased PRs
- [Bump no.nav.security:mock-oauth2-server from 2.3.0 to 3.0.0](https://github.com/navikt/amt-tiltak/pull/1107)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.5.5 to 3.5.6](https://github.com/navikt/amt-tiltak/pull/1106)
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.5.3 to 3.5.4](https://github.com/navikt/amt-tiltak/pull/1105)
- [Bump no.nav.poao-tilgang:client from 2025.07.04_08.56-814fa50f6740 to 2025.09.15_11.12-54be8ac278c0](https://github.com/navikt/amt-tiltak/pull/1104)
- [Bump no.nav.amt.lib:models from 1.2025.09.12_14.27-34cc8282593a to 1.2025.09.15_08.19-1c6bc06d65fe](https://github.com/navikt/amt-tiltak/pull/1103)


